### PR TITLE
bug: fix issue 17 (the snake kills itself when the oposite direction key is pressed) Closes #17

### DIFF
--- a/kobra.py
+++ b/kobra.py
@@ -257,7 +257,14 @@ while True:
         # Key pressed
         if event.type == pygame.KEYDOWN:
             # Down arrow (or S): move down
-            if event.key in (pygame.K_DOWN, pygame.K_s,) and snake.ymov != -1:
+            if (
+                event.key
+                in (
+                    pygame.K_DOWN,
+                    pygame.K_s,
+                )
+                and snake.ymov != -1
+            ):
                 snake.ymov = 1
                 snake.xmov = 0
             # Up arrow (or W): move up

--- a/kobra.py
+++ b/kobra.py
@@ -256,31 +256,28 @@ while True:
 
         # Key pressed
         if event.type == pygame.KEYDOWN:
-            if event.key in (
-                pygame.K_DOWN,
-                pygame.K_s,
-            ):  # Down arrow (or S):  move down
+            # Down arrow (or S): move down
+            if event.key in (pygame.K_DOWN, pygame.K_s,) and snake.ymov != -1:
                 snake.ymov = 1
                 snake.xmov = 0
-            elif event.key in (pygame.K_UP, pygame.K_w):  # Up arrow (or W):    move up
+            # Up arrow (or W): move up
+            elif event.key in (pygame.K_UP, pygame.K_w) and snake.ymov != 1:
                 snake.ymov = -1
                 snake.xmov = 0
-            elif event.key in (
-                pygame.K_RIGHT,
-                pygame.K_d,
-            ):  # Right arrow (or D): move right
+            # Right arrow (or D): move right
+            elif event.key in (pygame.K_RIGHT, pygame.K_d) and snake.xmov != -1:
                 snake.ymov = 0
                 snake.xmov = 1
-            elif event.key in (
-                pygame.K_LEFT,
-                pygame.K_a,
-            ):  # Left arrow (or A):  move left
+            # Left arrow (or A): move left
+            elif event.key in (pygame.K_LEFT, pygame.K_a) and snake.xmov != 1:
                 snake.ymov = 0
                 snake.xmov = -1
-            elif event.key == pygame.K_q:  # Q         : quit game
+            # Q : quit game
+            elif event.key == pygame.K_q:
                 pygame.quit()
                 sys.exit()
-            elif event.key == pygame.K_p:  # S         : pause game
+            # P : pause game
+            elif event.key == pygame.K_p:
                 game_on = not game_on
     ## Update the game
 


### PR DESCRIPTION
In this pull request, the snake can't kill itself anymore when an opposite direction key is pressed. Try, while the snake is going upwards, press the DOWN key. Or press UP key when its going downwards.

Although it works, this problem is only half fixed. If the user presses **quickly** RIGHT then UP when the snake is going downwards the snake dies anyway: as the current direction isn't down anymore when the RIGHT key is pressed, the UP movement is available again, and the snake dies.

Besides that, I think it's viable to merge these changes for now, then work on a different branch to fix the other part of this bug

Closes #17 