### PR TITLE
Adjusting Maximum Speed Cap for Better Gameplay Balance

### DIFF
--- a/kobra.py
+++ b/kobra.py
@@ -308,7 +308,7 @@ while True:
     if snake.head.x == apple.x and snake.head.y == apple.y:
         # snake.tail.append(pygame.Rect(snake.head.x, snake.head.y, GRID_SIZE, GRID_SIZE))
         snake.got_apple = True
-        snake.speed = min(snake.speed * 1.1, 20)  # Increase speed, max 20
+        snake.speed = min(snake.speed * 1.1, 10)  # Increase speed, max 20
         # print(f"[APPLE] Speed increased to: {snake.speed:.2f}")
         apple = Apple()
 


### PR DESCRIPTION
The current implementation increases the snake's speed by 10% for each apple eaten, with the speed capped at a maximum of 20. This can lead to an excessively high difficulty level after eating some apples. This change proposes reducing the maximum speed cap from 20 to 10 in the line snake.speed = min(snake.speed * 1.1, 20) to create a more manageable and balanced difficulty curve. #60 