### PR TITLE
fix: remove build system from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["uv>=0.2"]
-build-backend = "uv.build"
-
 [project]
 name = "naja"
 version = "0.1.0"


### PR DESCRIPTION
Removing `build-system` from pyproject.toml because it's unnecessary and breaks uv:

<img width="884" height="364" alt="image" src="https://github.com/user-attachments/assets/3c6d13e4-803c-4215-af67-ef5e8a728c2c" />

Closes #80 