### PR TITLE
code: add border to arena

### DIFF
--- a/kobra.py
+++ b/kobra.py
@@ -51,8 +51,8 @@ ARENA_COLOR = "#202020"  # Color of the ground.
 GRID_COLOR = "#3c3c3b"  # Color of the grid lines.
 SCORE_COLOR = "#ffffff"  # Color of the scoreboard.
 MESSAGE_COLOR = "#808080"  # Color of the game-over message.
-BORDER_COLOR = "#cccccc" # Color for the game arena border.
-BORDER_WIDTH = 2        # Width of the border in pixels.
+BORDER_COLOR = "#cccccc"  # Color for the game arena border.
+BORDER_WIDTH = 2  # Width of the border in pixels.
 
 WINDOW_TITLE = "KobraPy"  # Window title.
 
@@ -237,9 +237,11 @@ class Apple:
 ## Draw the arena
 ##
 
+
 # Function to draw the border
 def draw_border():
     pygame.draw.rect(arena, BORDER_COLOR, (0, 0, WIDTH, HEIGHT), BORDER_WIDTH)
+
 
 def draw_grid():
     for x in range(0, WIDTH, GRID_SIZE):

--- a/kobra.py
+++ b/kobra.py
@@ -51,6 +51,8 @@ ARENA_COLOR = "#202020"  # Color of the ground.
 GRID_COLOR = "#3c3c3b"  # Color of the grid lines.
 SCORE_COLOR = "#ffffff"  # Color of the scoreboard.
 MESSAGE_COLOR = "#808080"  # Color of the game-over message.
+BORDER_COLOR = "#cccccc" # Color for the game arena border.
+BORDER_WIDTH = 2        # Width of the border in pixels.
 
 WINDOW_TITLE = "KobraPy"  # Window title.
 
@@ -235,6 +237,9 @@ class Apple:
 ## Draw the arena
 ##
 
+# Function to draw the border
+def draw_border():
+    pygame.draw.rect(arena, BORDER_COLOR, (0, 0, WIDTH, HEIGHT), BORDER_WIDTH)
 
 def draw_grid():
     for x in range(0, WIDTH, GRID_SIZE):
@@ -300,6 +305,9 @@ while True:
         snake.update()
 
         arena.fill(ARENA_COLOR)
+        # Draw the border
+        draw_border()
+
         draw_grid()
 
         apple.update()


### PR DESCRIPTION
Continues implementation of #36 

This PR introduces a visual border to the game arena to clearly define the play area.

- A visible border is now drawn around the game's boundaries.