### PR TITLE
feat: add ESC key to open in-game menu (closes #94)

### DIFF
--- a/kobra.py
+++ b/kobra.py
@@ -608,7 +608,7 @@ while True:
                 sys.exit()
             elif event.key == pygame.K_p:  # P         : pause game
                 game_on = not game_on
-            elif event.key == pygame.K_m:
+            elif event.key in (pygame.K_m, pygame.K_ESCAPE):  # M or ESC : open menu
                 was_running = game_on
                 game_on = 0
                 run_settings_menu()


### PR DESCRIPTION
ESC is the standard key in games to open menus and is more intuitive for players. Now both ESC and M keys open the settings menu during gameplay for easier access.

closes #94.