### PR TITLE
bug: add 'Reset Game on Apply' toggle to preserve progress

### DIFF
--- a/kobra.py
+++ b/kobra.py
@@ -76,6 +76,7 @@ SETTINGS = {
     "death_sound": True,  # toggle death sound playback
     "obstacle_difficulty": "None",  # obstacle difficulty level
     "background_music": True,  # toggle background music playback
+    "reset_game_on_apply": False,  # reset game when applying settings
 }
 
 # Declarative menu fields.
@@ -112,6 +113,7 @@ MENU_FIELDS = [
         "options": ["None", "Easy", "Medium", "Hard", "Impossible"],
     },
     {"key": "background_music", "label": "Background Music", "type": "bool"},
+    {"key": "reset_game_on_apply", "label": "Reset Game on Apply", "type": "bool"},
 ]
 
 # Effective runtime values (hydrated by apply_settings).
@@ -695,7 +697,7 @@ while True:
                 was_running = game_on
                 game_on = 0
                 run_settings_menu()
-                apply_settings(reset_objects=True)
+                apply_settings(reset_objects=SETTINGS["reset_game_on_apply"])
                 game_on = was_running
             elif event.key == pygame.K_n:  # N : toggle music mute
                 SETTINGS["background_music"] = not SETTINGS["background_music"]

--- a/kobra.py
+++ b/kobra.py
@@ -83,7 +83,7 @@ SETTINGS = {
 MENU_FIELDS = [
     {
         "key": "cells_per_side",
-        "label": "Cells per side",
+        "label": "Cells per side (needs reset)",
         "type": "int",
         "min": 10,
         "max": 60,
@@ -91,7 +91,7 @@ MENU_FIELDS = [
     },
     {
         "key": "initial_speed",
-        "label": "Initial speed",
+        "label": "Initial speed (needs reset)",
         "type": "float",
         "min": 1.0,
         "max": 40.0,
@@ -108,7 +108,7 @@ MENU_FIELDS = [
     {"key": "death_sound", "label": "Death Sound", "type": "bool"},
     {
         "key": "obstacle_difficulty",
-        "label": "Obstacles",
+        "label": "Obstacles (needs reset)",
         "type": "select",
         "options": ["None", "Easy", "Medium", "Hard", "Impossible"],
     },
@@ -696,8 +696,23 @@ while True:
             elif event.key in (pygame.K_m, pygame.K_ESCAPE):  # M or ESC : open menu
                 was_running = game_on
                 game_on = 0
+                
+                # Store old values of critical settings
+                old_cells = SETTINGS["cells_per_side"]
+                old_obstacles = SETTINGS["obstacle_difficulty"]
+                old_initial_speed = SETTINGS["initial_speed"]
+                
                 run_settings_menu()
-                apply_settings(reset_objects=SETTINGS["reset_game_on_apply"])
+                
+                # Check if critical settings changed (require reset)
+                needs_reset = (
+                    old_cells != SETTINGS["cells_per_side"] or
+                    old_obstacles != SETTINGS["obstacle_difficulty"] or
+                    old_initial_speed != SETTINGS["initial_speed"]
+                )
+                
+                # Force reset if critical settings changed, or use player preference
+                apply_settings(reset_objects=needs_reset or SETTINGS["reset_game_on_apply"])
                 game_on = was_running
             elif event.key == pygame.K_n:  # N : toggle music mute
                 SETTINGS["background_music"] = not SETTINGS["background_music"]

--- a/kobra.py
+++ b/kobra.py
@@ -605,7 +605,8 @@ def main():
 
                     # Force reset if critical settings changed, or use player preference
                     apply_settings(
-                        state, reset_objects=needs_reset or SETTINGS["reset_game_on_apply"]
+                        state,
+                        reset_objects=needs_reset or SETTINGS["reset_game_on_apply"],
                     )
                     state.game_on = was_running
                 elif event.key == pygame.K_n:  # N : toggle music mute

--- a/kobra.py
+++ b/kobra.py
@@ -696,23 +696,25 @@ while True:
             elif event.key in (pygame.K_m, pygame.K_ESCAPE):  # M or ESC : open menu
                 was_running = game_on
                 game_on = 0
-                
+
                 # Store old values of critical settings
                 old_cells = SETTINGS["cells_per_side"]
                 old_obstacles = SETTINGS["obstacle_difficulty"]
                 old_initial_speed = SETTINGS["initial_speed"]
-                
+
                 run_settings_menu()
-                
+
                 # Check if critical settings changed (require reset)
                 needs_reset = (
-                    old_cells != SETTINGS["cells_per_side"] or
-                    old_obstacles != SETTINGS["obstacle_difficulty"] or
-                    old_initial_speed != SETTINGS["initial_speed"]
+                    old_cells != SETTINGS["cells_per_side"]
+                    or old_obstacles != SETTINGS["obstacle_difficulty"]
+                    or old_initial_speed != SETTINGS["initial_speed"]
                 )
-                
+
                 # Force reset if critical settings changed, or use player preference
-                apply_settings(reset_objects=needs_reset or SETTINGS["reset_game_on_apply"])
+                apply_settings(
+                    reset_objects=needs_reset or SETTINGS["reset_game_on_apply"]
+                )
                 game_on = was_running
             elif event.key == pygame.K_n:  # N : toggle music mute
                 SETTINGS["background_music"] = not SETTINGS["background_music"]


### PR DESCRIPTION
## Description
Added a new setting **"Reset Game on Apply"** that allows players to choose whether to reset the game when applying settings changes during gameplay. Additionally, implemented smart reset detection to automatically handle critical settings that require a game reset.

## Implementation
- Added **"Reset Game on Apply"** toggle in settings menu (default: Off)
- Added **"(needs reset)"** labels to critical settings for clear user guidance:
  - **Cells per side (needs reset)** - Grid size changes
  - **Initial speed (needs reset)** - Starting speed changes  
  - **Obstacles (needs reset)** - Obstacle difficulty changes
- Implemented automatic reset detection that tracks changes to critical settings
- When critical settings are modified, the game automatically resets regardless of the toggle state to prevent crashes and inconsistencies
- Safe settings (max speed, death sound, background music) can be changed mid-game without triggering a reset
- The **"Reset Game on Apply"** toggle provides manual control for optional resets in other situations
- Default behavior (Off) preserves snake position, progress, and score when only safe settings are changed

## How It Works
1. **Safe settings** (max speed, sounds, music) → No reset, progress preserved
2. **Critical settings** (grid size, obstacles, initial speed) → Automatic reset
3. **"Reset Game on Apply" toggle** → Optional manual reset for any other situations

Closes #106