### PR TITLE
feat: Add multiple apples support 

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -89,7 +89,7 @@ class Snake:
     # This function is called at each loop interation.
 
     def update(
-        self, apple: Apple, obstacles: list[Obstacle], game_over_func: Callable
+        self, apples: list[Apple], obstacles: list[Obstacle], game_over_func: Callable
     ) -> bool:
         """Update snake position and check for collisions.
 
@@ -161,8 +161,12 @@ class Snake:
             self.prev_head_x = self.x
             self.prev_head_y = self.y
 
-            # Reposition the apple
-            apple.ensure_valid_position(self, obstacles)
+            # Reposition all apples ensuring no overlap
+            for i, apple in enumerate(apples):
+                apple.ensure_valid_position(self, obstacles)
+                # Ensure this apple doesn't overlap with previously repositioned apples
+                while any(apple.x == apples[j].x and apple.y == apples[j].y for j in range(i)):
+                    apple.ensure_valid_position(self, obstacles)
 
         return died
 

--- a/entities.py
+++ b/entities.py
@@ -165,7 +165,9 @@ class Snake:
             for i, apple in enumerate(apples):
                 apple.ensure_valid_position(self, obstacles)
                 # Ensure this apple doesn't overlap with previously repositioned apples
-                while any(apple.x == apples[j].x and apple.y == apples[j].y for j in range(i)):
+                while any(
+                    apple.x == apples[j].x and apple.y == apples[j].y for j in range(i)
+                ):
                     apple.ensure_valid_position(self, obstacles)
 
         return died

--- a/kobra.py
+++ b/kobra.py
@@ -307,7 +307,7 @@ def apply_settings(state: GameState, reset_objects: bool = False) -> None:
     NUM_OBSTACLES = Obstacle.calculate_obstacles_from_difficulty(
         SETTINGS["obstacle_difficulty"], WIDTH, GRID_SIZE, HEIGHT
     )
-    
+
     # Calculate max apples based on a reasonable percentage of total cells
     # Limit to 15% of grid or 30 apples max (whichever is smaller)
     total_cells = (WIDTH // GRID_SIZE) * (HEIGHT // GRID_SIZE)
@@ -315,7 +315,7 @@ def apply_settings(state: GameState, reset_objects: bool = False) -> None:
     max_apples_absolute = 30  # Hard cap
     max_apples = max(1, min(max_apples_by_percent, max_apples_absolute))
     NUM_APPLES = min(int(SETTINGS["number_of_apples"]), max_apples)
-    
+
     MUSIC_ON = bool(SETTINGS["background_music"])
 
     # Control background music playback based on setting

--- a/kobra.py
+++ b/kobra.py
@@ -349,7 +349,7 @@ def apply_settings(state: GameState, reset_objects: bool = False) -> None:
         # Objects will be recreated in the game state
         state.snake = Snake(WIDTH, HEIGHT, GRID_SIZE)
         state.create_obstacles_constructively(NUM_OBSTACLES)
-        
+
         # Create multiple apples
         state.apples = []
         for _ in range(NUM_APPLES):
@@ -359,7 +359,7 @@ def apply_settings(state: GameState, reset_objects: bool = False) -> None:
             while any(apple.x == a.x and apple.y == a.y for a in state.apples):
                 apple.ensure_valid_position(state.snake, state.obstacles)
             state.apples.append(apple)
-        
+
         state.snake.speed = CLOCK_TICKS
 
 
@@ -785,24 +785,28 @@ def main():
                 state.snake.speed = min(
                     state.snake.speed * 1.1, MAX_SPEED
                 )  # Increase speed
-                
+
                 # Remove eaten apple and spawn a new one
                 state.apples.remove(apple)
-                
+
                 # Calculate available free cells
                 total_cells = (WIDTH // GRID_SIZE) * (HEIGHT // GRID_SIZE)
-                occupied_cells = 1 + len(state.snake.tail) + len(state.obstacles) + len(state.apples)
+                occupied_cells = (
+                    1 + len(state.snake.tail) + len(state.obstacles) + len(state.apples)
+                )
                 free_cells = total_cells - occupied_cells
-                
+
                 # Only spawn new apple if there are free cells
                 if free_cells > 0:
                     new_apple = Apple(WIDTH, HEIGHT, GRID_SIZE)
                     new_apple.ensure_valid_position(state.snake, state.obstacles)
                     # Ensure it doesn't overlap with existing apples
-                    while any(new_apple.x == a.x and new_apple.y == a.y for a in state.apples):
+                    while any(
+                        new_apple.x == a.x and new_apple.y == a.y for a in state.apples
+                    ):
                         new_apple.ensure_valid_position(state.snake, state.obstacles)
                     state.apples.append(new_apple)
-                
+
                 break  # Only eat one apple per frame
 
         # Update display

--- a/state.py
+++ b/state.py
@@ -34,7 +34,7 @@ class GameState:
     arena: pygame.Surface
     game_on: int
     snake: Snake
-    apple: Apple
+    apples: list[Apple]
     obstacles: list[Obstacle]
 
     # Private fields
@@ -67,8 +67,12 @@ class GameState:
         # Game objects (initialized with proper dimensions)
         self.snake = Snake(display_width, display_height, grid_size)
         self.obstacles = []  # Will be populated by create_obstacles if needed
-        self.apple = Apple(display_width, display_height, grid_size)
-        self.apple.ensure_valid_position(self.snake, self.obstacles)
+        
+        # Initialize with a single apple (will be updated by apply_settings)
+        self.apples = []
+        apple = Apple(display_width, display_height, grid_size)
+        apple.ensure_valid_position(self.snake, self.obstacles)
+        self.apples.append(apple)
 
     def update_dimensions(self, width: int, height: int, grid_size: int) -> None:
         """Update the game dimensions.

--- a/state.py
+++ b/state.py
@@ -67,7 +67,7 @@ class GameState:
         # Game objects (initialized with proper dimensions)
         self.snake = Snake(display_width, display_height, grid_size)
         self.obstacles = []  # Will be populated by create_obstacles if needed
-        
+
         # Initialize with a single apple (will be updated by apply_settings)
         self.apples = []
         apple = Apple(display_width, display_height, grid_size)


### PR DESCRIPTION
## Description
- Added 'Number of apples' setting to game settings menu
- Updated GameState to manage list of apples instead of single apple
- Modified Snake.update() to accept list of apples
- Game loop now maintains N apples in the arena at all times
- Apples are automatically respawned when eaten (if free cells available)
- Added validation to prevent apple overlap
- Number of apples limited by available free grid squares
- Added 'number_of_apples' to critical settings requiring reset

## Implementation details:
- Default: 1 apple (classic behavior)
- Max: 15% of grid cells or 30 apples (whichever is smaller)
- When snake eats apple, new one spawns immediately
- End-game: fills remaining free squares when N > free cells
- All apples properly repositioned on game reset
- Menu cap set to 30 for gameplay balance

(closes #88)