### PR TITLE
feat: add an option to disable electric walls

### DIFF
--- a/kobra.py
+++ b/kobra.py
@@ -518,6 +518,17 @@ def draw_music_indicator(
     state.arena.blit(hint_surf, hint_rect)
 
 
+def _will_wrap_around(state: GameState, origin: int, dest: int, limit: int) -> bool:
+    """
+    Checks if an object on the game's grid will wrap around by moving in a
+    straight line (horizontally or vertically) from origin to dest.
+
+    The limit parameter should be either the arena's width or height.
+    """
+
+    return abs(abs(origin - dest) - limit) <= state.grid_size
+
+
 ##
 ## Main game function
 ##
@@ -610,6 +621,7 @@ def main():
                     old_obstacles = settings.get("obstacle_difficulty")
                     old_initial_speed = settings.get("initial_speed")
                     old_num_apples = settings.get("number_of_apples")
+                    old_electric_walls = settings.get("electric_walls")
 
                     run_settings_menu(state, assets, settings)
 
@@ -619,6 +631,7 @@ def main():
                         or old_obstacles != settings.get("obstacle_difficulty")
                         or old_initial_speed != settings.get("initial_speed")
                         or old_num_apples != settings.get("number_of_apples")
+                        or old_electric_walls != settings.get("electric_walls")
                     )
 
                     # Force reset if critical settings changed, or use player preference
@@ -649,6 +662,7 @@ def main():
                         state.apples,
                         state.obstacles,
                         lambda: game_over_handler(state, assets, settings),
+                        settings.get("electric_walls")
                     )
 
             # Advance interpolation toward the current target grid cell (if any)
@@ -658,18 +672,40 @@ def main():
             ):
                 move_interval_ms = 1000.0 / state.snake.speed
                 state.snake.move_progress += dt / move_interval_ms
+
                 if state.snake.move_progress > 1.0:
                     state.snake.move_progress = 1.0
-                state.snake.draw_x = (
-                    state.snake.head.x
-                    + (state.snake.target_x - state.snake.head.x)
-                    * state.snake.move_progress
-                )
-                state.snake.draw_y = (
-                    state.snake.head.y
-                    + (state.snake.target_y - state.snake.head.y)
-                    * state.snake.move_progress
-                )
+
+                electric_walls = settings.get("electric_walls")
+
+                # We multiply by xmov (respectively, ymov) so that the snake
+                # keeps moving in the direction it was moving earlier 
+                if not electric_walls and _will_wrap_around(state, state.snake.head.x, state.snake.target_x, state.snake.width):
+                    state.snake.draw_x = (
+                        state.snake.head.x
+                        + state.snake.xmov
+                        * state.grid_size * state.snake.move_progress
+                    )
+                else:
+                    state.snake.draw_x = (
+                        state.snake.head.x
+                        + (state.snake.target_x - state.snake.head.x)
+                        * state.snake.move_progress
+                    )
+
+                if not electric_walls and _will_wrap_around(state, state.snake.head.y, state.snake.target_y, state.snake.height):
+                    state.snake.draw_y = (
+                        state.snake.head.y
+                        + state.snake.ymov
+                        * state.grid_size * state.snake.move_progress
+                    )
+                else:
+                    state.snake.draw_y = (
+                        state.snake.head.y
+                        + (state.snake.target_y - state.snake.head.y)
+                        * state.snake.move_progress
+                    )
+
                 if state.snake.move_progress >= 1.0:
                     # Move completed: remember previous head position
                     prev_x = state.snake.head.x
@@ -713,22 +749,29 @@ def main():
         for apple in state.apples:
             apple.update(state.arena)
 
+        electric_walls = settings.get("electric_walls")
+
         # Draw the tail with smooth interpolation
         for i, (tx, ty) in enumerate(state.snake.tail):
             draw_tx = tx
             draw_ty = ty
 
-            if i == 0 and state.snake.move_progress > 0.0:
-                draw_tx = state.snake.head.x + (tx - state.snake.head.x) * (
-                    1.0 - state.snake.move_progress
-                )
-                draw_ty = state.snake.head.y + (ty - state.snake.head.y) * (
-                    1.0 - state.snake.move_progress
-                )
-            elif i > 0 and state.snake.move_progress > 0.0:
+            if i == 0:
+                prev_tx = state.snake.head.x
+                prev_ty = state.snake.head.y
+            else:
                 prev_tx, prev_ty = state.snake.tail[i - 1]
-                draw_tx = prev_tx + (tx - prev_tx) * (1.0 - state.snake.move_progress)
-                draw_ty = prev_ty + (ty - prev_ty) * (1.0 - state.snake.move_progress)
+
+            if state.snake.move_progress > 0.0:
+                if not electric_walls and _will_wrap_around(state, prev_tx, tx, state.snake.width):
+                    draw_tx = prev_tx + state.snake.xmov * state.grid_size * state.snake.move_progress
+                else:
+                    draw_tx = prev_tx + (tx - prev_tx) * (1.0 - state.snake.move_progress)
+
+                if not electric_walls and _will_wrap_around(state, prev_ty, ty, state.snake.height):
+                    draw_ty = prev_ty + state.snake.ymov * state.grid_size * state.snake.move_progress
+                else:
+                    draw_ty = prev_ty + (ty - prev_ty) * (1.0 - state.snake.move_progress)
 
             pygame.draw.rect(
                 state.arena,

--- a/kobra.py
+++ b/kobra.py
@@ -662,7 +662,7 @@ def main():
                         state.apples,
                         state.obstacles,
                         lambda: game_over_handler(state, assets, settings),
-                        settings.get("electric_walls")
+                        settings.get("electric_walls"),
                     )
 
             # Advance interpolation toward the current target grid cell (if any)
@@ -679,12 +679,13 @@ def main():
                 electric_walls = settings.get("electric_walls")
 
                 # We multiply by xmov (respectively, ymov) so that the snake
-                # keeps moving in the direction it was moving earlier 
-                if not electric_walls and _will_wrap_around(state, state.snake.head.x, state.snake.target_x, state.snake.width):
+                # keeps moving in the direction it was moving earlier
+                if not electric_walls and _will_wrap_around(
+                    state, state.snake.head.x, state.snake.target_x, state.snake.width
+                ):
                     state.snake.draw_x = (
                         state.snake.head.x
-                        + state.snake.xmov
-                        * state.grid_size * state.snake.move_progress
+                        + state.snake.xmov * state.grid_size * state.snake.move_progress
                     )
                 else:
                     state.snake.draw_x = (
@@ -693,11 +694,12 @@ def main():
                         * state.snake.move_progress
                     )
 
-                if not electric_walls and _will_wrap_around(state, state.snake.head.y, state.snake.target_y, state.snake.height):
+                if not electric_walls and _will_wrap_around(
+                    state, state.snake.head.y, state.snake.target_y, state.snake.height
+                ):
                     state.snake.draw_y = (
                         state.snake.head.y
-                        + state.snake.ymov
-                        * state.grid_size * state.snake.move_progress
+                        + state.snake.ymov * state.grid_size * state.snake.move_progress
                     )
                 else:
                     state.snake.draw_y = (
@@ -763,15 +765,29 @@ def main():
                 prev_tx, prev_ty = state.snake.tail[i - 1]
 
             if state.snake.move_progress > 0.0:
-                if not electric_walls and _will_wrap_around(state, prev_tx, tx, state.snake.width):
-                    draw_tx = prev_tx + state.snake.xmov * state.grid_size * state.snake.move_progress
+                if not electric_walls and _will_wrap_around(
+                    state, prev_tx, tx, state.snake.width
+                ):
+                    draw_tx = (
+                        prev_tx
+                        + state.snake.xmov * state.grid_size * state.snake.move_progress
+                    )
                 else:
-                    draw_tx = prev_tx + (tx - prev_tx) * (1.0 - state.snake.move_progress)
+                    draw_tx = prev_tx + (tx - prev_tx) * (
+                        1.0 - state.snake.move_progress
+                    )
 
-                if not electric_walls and _will_wrap_around(state, prev_ty, ty, state.snake.height):
-                    draw_ty = prev_ty + state.snake.ymov * state.grid_size * state.snake.move_progress
+                if not electric_walls and _will_wrap_around(
+                    state, prev_ty, ty, state.snake.height
+                ):
+                    draw_ty = (
+                        prev_ty
+                        + state.snake.ymov * state.grid_size * state.snake.move_progress
+                    )
                 else:
-                    draw_ty = prev_ty + (ty - prev_ty) * (1.0 - state.snake.move_progress)
+                    draw_ty = prev_ty + (ty - prev_ty) * (
+                        1.0 - state.snake.move_progress
+                    )
 
             pygame.draw.rect(
                 state.arena,

--- a/src/entities.py
+++ b/src/entities.py
@@ -89,7 +89,11 @@ class Snake:
     # This function is called at each loop interation.
 
     def update(
-        self, apples: list[Apple], obstacles: list[Obstacle], game_over_func: Callable, electric_walls: bool
+        self,
+        apples: list[Apple],
+        obstacles: list[Obstacle],
+        game_over_func: Callable,
+        electric_walls: bool,
     ) -> bool:
         """Update snake position and check for collisions.
 
@@ -106,8 +110,8 @@ class Snake:
         if self.xmov or self.ymov:
             # Check for border crash.
             if electric_walls and (
-                next_x not in range(0, self.width) or
-                next_y not in range(0, self.height)
+                next_x not in range(0, self.width)
+                or next_y not in range(0, self.height)
             ):
                 self.alive = False
                 died = True

--- a/src/entities.py
+++ b/src/entities.py
@@ -89,7 +89,7 @@ class Snake:
     # This function is called at each loop interation.
 
     def update(
-        self, apples: list[Apple], obstacles: list[Obstacle], game_over_func: Callable
+        self, apples: list[Apple], obstacles: list[Obstacle], game_over_func: Callable, electric_walls: bool
     ) -> bool:
         """Update snake position and check for collisions.
 
@@ -105,11 +105,15 @@ class Snake:
         # Only check collisions if the snake is currently moving
         if self.xmov or self.ymov:
             # Check for border crash.
-            if next_x not in range(0, self.width) or next_y not in range(
-                0, self.height
+            if electric_walls and (
+                next_x not in range(0, self.width) or
+                next_y not in range(0, self.height)
             ):
                 self.alive = False
                 died = True
+            else:
+                next_x %= self.width
+                next_y %= self.height
 
             # Check for self-bite.
             for square in self.tail:

--- a/src/settings.py
+++ b/src/settings.py
@@ -34,6 +34,7 @@ class GameSettings:
         "background_music": True,
         "reset_game_on_apply": False,
         "eat_sound": True,
+        "electric_walls": True,
     }
 
     # Declarative menu field definitions
@@ -83,7 +84,11 @@ class GameSettings:
             "key": "eat_sound",
             "label": "eat sound",
             "type": "bool",
-            "default": True,
+        },
+        {
+            "key": "electric_walls",
+            "label": "Electric walls (needs reset)",
+            "type": "bool",
         },
     ]
 


### PR DESCRIPTION
I've implemented an option to allow disabling electric walls/death border in the arena. Currently, it just checks if any piece of the snake would wrap around while being moved; if so, it keeps moving that piece "out-of-bounds" and then "teleports" it to the other side of the screen when it reaches its final position (`snake.movement_progress == 1`). This results in a smooth transition in one side of the screen and a more jagged one on the other side.

While this issue could be fixed, it would introduce additional complexity, so I haven't solved it yet. Though I should note I've thought of two ways to fix it:

 - When a snake piece wraps around, spend half of the "movement progress counter" moving it out-of-bounds such that it is completely hidden at `snake.movement_progress == 0.5`, and then use the other half to move it in-bounds on the other side of the screen.
  
    While easier to implement, it would still feel "wrong" to the keen eye, as it would seem like that piece of the snake is temporarily stuck on an extra invisible tile that's out-of-bounds. Either using a nonlinear progress function or avoiding ever totally occluding the snake piece might remedy that, I'm not sure.
  
  - When a snake piece wraps around, render two pieces on both sides of the screen. This one is more correct but possibly more complex too.
  
  Either way, I could extend this PR to implement one of these two behaviors if it improves UX.
  
  Closes #74