### PR TITLE
code: refactor get_free_cells_count

### DIFF
--- a/src/state.py
+++ b/src/state.py
@@ -361,7 +361,9 @@ class GameState:
         Returns:
             Number of free cells
         """
-        occupied = len(self.obstacles) + len(self.snake.tail) + 1  # +1 for head
+        occupied = (
+            len(self.obstacles) + len(self.snake.tail) + len(self.apples) + 1
+        )  # +1 for head
         return self.total_cells - occupied
 
     def recreate_arena(self) -> None:


### PR DESCRIPTION
Fix #157

I just refactored `get_free_cells_count` to remove the amount of apples from the total count. Now the function _really_ represents the free cells: excluding the snake, the obstacles _and_ the apples.

I tested on different game modes and it seems to work. It guarantees that if there is a free cell, an apple can effectively spawn. The game does not crash in the end anymore - the snake is able to eat all the apples until it covers the entire board. When that happens, the snake collides with itself and the "game over" event is triggered.

It can be a further issue to implement an event for this action, as completing the board may not be considered "game over".