### PR TITLE
doc: add alternative pip/venv setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Quick Start
    # Or directly: uv run python kobra.py
    ```
 
+**Alternative (using Pip):**
+   1. Create and activate a virtual environment:
+      ```bash
+      python -m venv .venv
+      source .venv/bin/activate # On Windows: .venv\Scripts\activate
+      ```
+   2. Install and run:
+      ```bash
+      pip install .
+      python kobra.py
+      ```
+
 ### For Contributors
 
 **Requirements**: Python 3.12+, [uv](https://docs.astral.sh/uv/getting-started/installation/)
@@ -58,6 +70,17 @@ Quick Start
    - Read `docs/CONTRIBUTING.md` for detailed guidelines
    - Create an issue first to discuss your changes
    - Follow the Git workflow described in the contributing guide
+
+**Alternative (using Pip):**
+   1. Create and activate a virtual environment:
+      ```bash
+      python -m venv .venv
+      source .venv/bin/activate # On Windows: .venv\Scripts\activate
+      ```
+   2. Install all dependencies:
+      ```bash
+      pip install .[dev]
+      ```
 
 Getting Started
 ------------------------------

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -89,6 +89,23 @@ This command will:
 - Install all development dependencies (`uv sync --dev`)
 - Set up pre-commit hooks (`uv run pre-commit install`)
 
+### Manual Setup (Pip + Venv)
+
+If you prefer not to use `make` or `uv`, you can set up the environment manually with Python's standard tools:
+
+1. **Create and activate a virtual environment:**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate # On Windows, use .venv\Scripts\activate
+   ```
+
+2. **Install all dependencies:**
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
 ### Development Commands
 
 Use these Makefile commands during development:


### PR DESCRIPTION
This PR enhances the project's documentation by adding alternative setup instructions using Python's standard `pip` and `venv` tools.

This change makes the project more accessible to contributors who may not have `uv` installed, lowering the initial barrier to entry.

The new instructions are provided as an alternative to the existing `make`/`uv` workflow, which remains the recommended primary method.

**Changes:**
- Updated `README.md` with pip instructions for both players and contributors.
- Updated `docs/CONTRIBUTING.md` with a manual setup section using pip and venv.

Closes #273