### PR TITLE
Feat/147/makes audio optional

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -79,9 +79,11 @@ class ECSGameApp:
         self.pygame_adapter = PygameIOAdapter()
         self.pygame_adapter.init()
 
-        # verify if background music is enabled
-        if self.settings.get("background_music"):
-            self.pygame_adapter.init_mixer()
+        # initialize mixer for music and sound effects
+        try:
+            pygame.mixer.init()
+        except pygame.error:
+            self.settings.set("background_music", False)
 
         # create game window
         self.surface = self.pygame_adapter.set_mode(

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -67,10 +67,6 @@ class ECSGameApp:
 
     def initialize(self) -> None:
         """Initialize all game systems and resources."""
-        # initialize pygame
-        self.pygame_adapter = PygameIOAdapter()
-        self.pygame_adapter.init()
-        self.pygame_adapter.init_mixer()
 
         # initialize configuration
         self.config = GameConfig()
@@ -79,6 +75,13 @@ class ECSGameApp:
         self.settings = GameSettings(
             self.config.initial_width, self.config.initial_grid_size
         )
+        # initialize pygame
+        self.pygame_adapter = PygameIOAdapter()
+        self.pygame_adapter.init()
+
+        # verify if background music is enabled
+        if self.settings.get("background_music"):
+            self.pygame_adapter.init_mixer()
 
         # create game window
         self.surface = self.pygame_adapter.set_mode(


### PR DESCRIPTION
When trying to run the game without an audio device, the game crashes. The exact error can be seen bellow:
<img width="1192" height="237" alt="image" src="https://github.com/user-attachments/assets/d465c652-179d-4185-a0b5-b1b2f698ec95" />

To avoid this, I've added a try catch before initializing the mixer, if an error occurs, the background music is deactivated