### PR TITLE
[FIX] The eat sound is incredible loud

### DIFF
--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -289,7 +289,7 @@ class CollisionSystem(BaseSystem):
 
                     # play apple eating sound
                     if self._audio_service:
-                        self._audio_service.play_sound("assets/sound/eat.flac")
+                        self._audio_service.play_sound("assets/sound/eat.flac", volume=0.2)
 
                     # grow snake
                     if hasattr(snake, "body"):

--- a/src/game/services/audio_service.py
+++ b/src/game/services/audio_service.py
@@ -48,11 +48,12 @@ class AudioService:
         """
         self._settings = settings
 
-    def play_sound(self, sound_path: str) -> bool:
+    def play_sound(self, sound_path: str, volume: float = 1.0) -> bool:
         """Play a sound effect if sound effects are enabled.
 
         Args:
             sound_path: Path to sound file (relative to project root)
+            volume: Volume level (0.0 to 1.0), defaults to 1.0 (full volume)
 
         Returns:
             True if sound was played, False otherwise
@@ -63,6 +64,9 @@ class AudioService:
 
         try:
             sound = pygame.mixer.Sound(sound_path)
+            # Clamp volume to valid range (0.0 to 1.0)
+            volume = max(0.0, min(1.0, volume))
+            sound.set_volume(volume)
             sound.play()
             return True
         except Exception:


### PR DESCRIPTION
The eating sound was too loud, which was very unpleasant. To fix this, I added a new parameter to the play_sound() function in audio_service.py. I set its default value to 1.0 (i.e., 100% volume) and defined the eating sound volume as 0.2, which provides a better experience.