### PR TITLE
feat: fix fast direction self collision

### DIFF
--- a/docs/adr/0001-choose-ecs.md
+++ b/docs/adr/0001-choose-ecs.md
@@ -31,7 +31,7 @@ This pattern separates data from behavior, making each piece small, focused, and
 
 **Negative:**
 - ❌ More files/abstractions than traditional OOP
-- ❌ Learning curve for contributors 
+- ❌ Learning curve for contributors
 
 **Mitigations:**
 - Comprehensive documentation in `docs/architecture.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Naja ECS Architecture
 
-> **Version:** 1.0 
+> **Version:** 1.0
 > **Last Updated:** October 2025
 > **Status:** Fully Implemented
 
@@ -76,11 +76,11 @@ class Position:
 ```python
 class MovementSystem(BaseSystem):
     """Moves entities based on velocity."""
-    
+
     def update(self, world):
         # Query entities with position + velocity
         entities = world.registry.query_by_component("position", "velocity")
-        
+
         for entity in entities.values():
             # Update position based on velocity
             entity.position.prev_x = entity.position.x
@@ -181,10 +181,10 @@ Systems in `src/ecs/systems/` process entities:
 ```python
 class InputSystem(BaseSystem):
     """Converts input into component changes."""
-    
+
     # Reads: pygame events
     # Writes: Velocity, GameState
-    
+
     # Example: right arrow
     if key == K_RIGHT and velocity.dx != -1:
         velocity.dx = 1
@@ -395,7 +395,7 @@ class AppleConfig:
 
 ```python
 # src/ecs/prefabs/apple.py
-def create_apple(world: World, x: int, y: int, grid_size: int, 
+def create_apple(world: World, x: int, y: int, grid_size: int,
                  color=None, points=10, growth=1) -> int:
     """Creates apple at position (x, y) with configured components."""
     apple = Apple(
@@ -424,17 +424,17 @@ class AppleSpawnSystem(BaseSystem):
     def update(self, world: World) -> None:
         # 1. How many do we want?
         desired_count = self._get_desired_apple_count(world)
-        
+
         # 2. How many do we have?
         current_apples = world.registry.query_by_type(EntityType.APPLE)
         current_count = len(current_apples)
-        
+
         # 3. Spawn difference
         for _ in range(desired_count - current_count):
             position = self._find_valid_position(world)
             if position:
                 create_apple(world, x=position[0], y=position[1], ...)
-    
+
     def _find_valid_position(self, world):
         """Finds position that doesn't collide with anything."""
         occupied = self._get_occupied_positions(world)
@@ -488,10 +488,10 @@ def test_spawn_maintains_apple_count():
     # Setup: want 3 apples
     config = Entity(apple_config=AppleConfig(desired_count=3))
     world.registry.add(config)
-    
+
     # Execute system
     system.update(world)
-    
+
     # Verify: has 3 apples?
     assert len(world.registry.query_by_type(EntityType.APPLE)) == 3
 
@@ -618,16 +618,16 @@ snake.velocity.dx = 1
 ```python
 class CollisionSystem(BaseSystem):
     """Detects snake vs apple/obstacle/wall collisions."""
-    
+
     def update(self, world):
         # Get snake
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         if not snakes:
             return
-        
+
         snake_id, snake = next(iter(snakes.items()))
         head_pos = (snake.position.x, snake.position.y)
-        
+
         # Check collision with apples
         apples = world.registry.query_by_type(EntityType.APPLE)
         for apple_id, apple in apples.items():
@@ -636,7 +636,7 @@ class CollisionSystem(BaseSystem):
                 # Collision! Grow snake and remove apple
                 snake.body.size += 1
                 world.registry.remove(apple_id)
-                
+
                 # Update score
                 score_entities = world.registry.query_by_component("score")
                 if score_entities:
@@ -655,23 +655,23 @@ def test_movement_system_moves_entity():
     # Setup
     board = Board(width=20, height=20, cell_size=20)
     world = World(board)
-    
+
     # Create test entity
     entity = Entity(
         position=Position(x=10, y=10),
         velocity=Velocity(dx=1, dy=0, speed=10.0)
     )
     entity_id = world.registry.add(entity)
-    
+
     # Create system
     system = MovementSystem()
-    
+
     # Simulate enough time to move
     world.dt_ms = 100  # 100ms
-    
+
     # Execute
     system.update(world)
-    
+
     # Verify
     entity = world.registry.get(entity_id)
     assert entity.position.x == 11
@@ -686,30 +686,30 @@ def test_snake_eats_apple():
     # Setup
     board = Board(width=20, height=20, cell_size=20)
     world = World(board)
-    
+
     # Create snake and apple at same position
     snake_id = create_snake(world, grid_size=20)
     snake = world.registry.get(snake_id)
     snake.position.x = 10
     snake.position.y = 10
-    
+
     apple_id = create_apple(world, grid_size=20)
     apple = world.registry.get(apple_id)
     apple.position.x = 10
     apple.position.y = 10
-    
+
     # Create score
     score_entity = Entity(score=Score(current=0))
     world.registry.add(score_entity)
-    
+
     # Execute collision system
     collision_system = CollisionSystem(settings=None, audio_service=None)
     collision_system.update(world)
-    
+
     # Verify
     assert snake.body.size == 2  # grew
     assert world.registry.get(apple_id) is None  # apple removed
-    
+
     score_entities = world.registry.query_by_component("score")
     score_entity = next(iter(score_entities.values()))
     assert score_entity.score.current == 10
@@ -751,4 +751,3 @@ pytest tests/ecs/test_movement_system.py  # specific test
 - `docs/CONTRIBUTING.md` - contribution guide
 - `docs/manual.md` - user manual
 - `.cursor/rules/` - detailed ECS rules
-

--- a/src/ecs/components/input_buffer.py
+++ b/src/ecs/components/input_buffer.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+
+@dataclass
+class InputBuffer:
+    """Buffered directions for an entity (snake). Each entry is (dx, dy)."""
+
+    moves: List[Tuple[int, int]] = field(default_factory=list)
+    max_len: int = 2  # maximum number of buffered moves

--- a/src/ecs/entities/snake.py
+++ b/src/ecs/entities/snake.py
@@ -27,6 +27,7 @@ from src.ecs.components.velocity import Velocity
 from src.ecs.components.snake_body import SnakeBody
 from src.ecs.components.interpolation import Interpolation
 from src.ecs.components.renderable import Renderable
+from src.ecs.components.input_buffer import InputBuffer
 
 
 @dataclass
@@ -49,6 +50,7 @@ class Snake(Entity):
     body: SnakeBody
     interpolation: Interpolation
     renderable: Renderable
+    input_buffer: InputBuffer
 
     def get_type(self) -> EntityType:
         """Get the type of this entity.

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -28,6 +28,7 @@ from src.ecs.components.snake_body import SnakeBody
 from src.ecs.components.interpolation import Interpolation
 from src.ecs.components.renderable import Renderable
 from src.core.types.color import Color
+from src.ecs.components.input_buffer import InputBuffer
 
 
 def create_snake(
@@ -78,6 +79,7 @@ def create_snake(
             secondary_color=Color(tail_color[0], tail_color[1], tail_color[2]),
             size=grid_size,
         ),
+        input_buffer=InputBuffer(),
     )
 
     # register entity with world and return ID

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -189,8 +189,6 @@ class CollisionSystem(BaseSystem):
     def _check_self_bite(self, world: World) -> bool:
         """Check if snake head collides with its own tail.
 
-        Maintains exact logic from old code.
-
         Args:
             world: ECS world
 
@@ -202,27 +200,26 @@ class CollisionSystem(BaseSystem):
             not snake
             or not hasattr(snake, "position")
             or not hasattr(snake, "velocity")
+            or not hasattr(snake, "body")
         ):
             return False
-        if not hasattr(snake, "body"):
-            return False
 
-        # calculate next position
-        next_x = snake.position.x + snake.velocity.dx
-        next_y = snake.position.y + snake.velocity.dy
+        # calculate head position
+        head_x = snake.position.x
+        head_y = snake.position.y
 
         # wrap if electric walls are disabled
         electric_walls = (
             self._settings.get("electric_walls") if self._settings else True
         )
         if not electric_walls:
-            next_x = next_x % world.board.width
-            next_y = next_y % world.board.height
+            head_x = head_x % world.board.width
+            head_y = head_y % world.board.height
 
         # check collision with tail segments
         tail_positions = [(seg.x, seg.y) for seg in snake.body.segments]
         for square in tail_positions:
-            if next_x == square[0] and next_y == square[1]:
+            if head_x == square[0] and head_y == square[1]:
                 return True
 
         return False

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -94,7 +94,17 @@ class InputSystem(BaseSystem):
             game_state.next_scene = "menu"
 
     def _buffer_direction(self, world: World, dx: int, dy: int) -> None:
-        """Append a new direction to the snake's input buffer if valid."""
+        """Append a new direction to the snake's input buffer if valid.
+
+        This method ensures that rapid direction changes are stored in order
+        and prevents immediate 180° reversals. It also respects the buffer's
+        maximum length.
+
+        Args:
+            world: ECS world containing the snake entity
+            dx: Horizontal component of the direction (-1, 0, 1)
+            dy: Vertical component of the direction (-1, 0, 1)
+        """
         snake = self._get_snake_entity(world)
         if not snake:
             return

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -93,6 +93,37 @@ class InputSystem(BaseSystem):
         if game_state:
             game_state.next_scene = "menu"
 
+    def _buffer_direction(self, world: World, dx: int, dy: int) -> None:
+        """Append a new direction to the snake's input buffer if valid."""
+        snake = self._get_snake_entity(world)
+        if not snake:
+            return
+
+        # get or create input buffer on the snake entity
+        if not hasattr(snake, "input_buffer") or snake.input_buffer is None:
+            # fallback: create attribute if prefabs didn't add it
+            from src.ecs.components.input_buffer import InputBuffer
+
+            snake.input_buffer = InputBuffer()
+
+        buf = snake.input_buffer
+
+        # get last buffered direction or current velocity if buffer is empty
+        last_dx, last_dy = (snake.velocity.dx, snake.velocity.dy)
+        if buf.moves:
+            last_dx, last_dy = buf.moves[-1]
+
+        if (dx != 0 and last_dx == -dx) or (dy != 0 and last_dy == -dy):
+            # don't queue a reversal against the last buffered direction
+            return
+
+        # Limit buffer length
+        if len(buf.moves) >= buf.max_len:
+            return
+
+        # Enqueue the new direction
+        buf.moves.append((dx, dy))
+
     def _handle_keydown(self, world: World, key: int) -> None:
         """Handle key down events.
 
@@ -105,13 +136,13 @@ class InputSystem(BaseSystem):
 
         # movement keys - modify velocity directly with 180° turn prevention
         if key in (pygame.K_DOWN, pygame.K_s):
-            self._set_direction(world, 0, 1, current_dx, current_dy)
+            self._buffer_direction(world, 0, 1)
         elif key in (pygame.K_UP, pygame.K_w):
-            self._set_direction(world, 0, -1, current_dx, current_dy)
+            self._buffer_direction(world, 0, -1)
         elif key in (pygame.K_RIGHT, pygame.K_d):
-            self._set_direction(world, 1, 0, current_dx, current_dy)
+            self._buffer_direction(world, 1, 0)
         elif key in (pygame.K_LEFT, pygame.K_a):
-            self._set_direction(world, -1, 0, current_dx, current_dy)
+            self._buffer_direction(world, -1, 0)
         # control keys
         elif key == pygame.K_q:
             self._handle_quit(world)

--- a/src/ecs/systems/movement.py
+++ b/src/ecs/systems/movement.py
@@ -168,6 +168,12 @@ class MovementSystem(BaseSystem):
                     )
                     body.segments.append(new_seg)
 
+            # Check if there's a buffered direction to apply
+            if hasattr(snake, "input_buffer") and snake.input_buffer.moves:
+                next_dx, next_dy = snake.input_buffer.moves.pop(0)
+                velocity.dx = next_dx
+                velocity.dy = next_dy
+
             # Move head by exactly one grid cell in velocity direction
             # Only wrap around if electric walls are disabled
             # If electric walls are enabled, collision system will handle out-of-bounds


### PR DESCRIPTION
The game now buffers user inputs before executing snake movement. Rapid direction changes (e.g., up → left → down) are processed in order, preventing the snake from dying due to immediate opposite-direction inputs. The input buffer currently holds up to two moves, allowing the game to execute a maximum of two consecutive movements.

closes #296
closes #75
closes #163 