### PR TITLE
[FEAT] Add game modes menu

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -52,9 +52,14 @@ But there's a catch: the snake lengthens each time it eats an apple.
 
 Naja offers different game modes to enhance your experience:
 
-- **Classic Mode** (Available): Traditional snake game with regular apples only
-- **More Fruits Mode** (Coming Soon): Features multiple fruit varieties with different point values
-- **Poisoned Apple Mode** (Coming Soon): Adds deadly poisoned apples that end the game on contact
+- **Classic Mode**: Traditional snake game with regular apples only
+- **More Fruits Mode**: Features multiple fruit varieties with different growth rates and speed effects
+  - 🍎 Apple (Red): +1 segment, speed up, 65% spawn rate
+  - 🍇 Grape (Purple): +1 segment, slow down, 25% spawn rate
+  - 🍊 Orange: +2 segments, speed up, 10% spawn rate (rare!)
+- **Poisoned Apple Mode**: Watch out for deadly poisoned apples!
+  - Regular Apple (Red): Always present, safe to eat
+  - Poisoned Apple (Dark Purple): Occasionally appears, instant game over on contact!
 
 Access game modes from the main menu by selecting "Game Modes".
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -51,12 +51,26 @@ But there’s a catch: the snake lengthens each time it eats an apple.
 Controls
 ------------------------------
 
+### Gameplay Controls
   * `arrow keys or WASD`: move the snake up, down, left, right
-  * `Q`: quit the game at any time
-  * `P`: pause the game at any time
-  * `ESC / M`: open menu
-  * `N`: mute the music
+  * `Q`: quit to main menu
+  * `P`: pause the game
+  * `ESC or M`: open in-game settings (adjust audio and colors without exiting)
+  * `N`: toggle audio (music and sound effects)
+  * `C`: randomize snake colors
 
+### In-Game Settings Menu
+When you press `ESC` or `M` during gameplay, you can adjust:
+  * Background Music (on/off)
+  * Sound Effects (on/off)
+  * Snake Color (choose from available palettes)
+  * Return to Main Menu (quit current game)
+
+Use `W/S` or arrow keys to navigate, `A/D` or arrow keys to adjust values, `Enter` to select, and `ESC` to return to the game.
+
+Note: Settings that require a game reset (like grid size, speed, obstacles) are only available in the main menu before starting a game.
+
+### Game Over
 When the game ends, press any key to restart or 'q' to quit.
 
 Getting Started

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -46,7 +46,17 @@ its own tail.
 The score is the number of apples eaten before the snake dies and the game ends.
 The goal is to collect as many apples as possible.
 
-But there’s a catch: the snake lengthens each time it eats an apple.
+But there's a catch: the snake lengthens each time it eats an apple.
+
+### Game Modes
+
+Naja offers different game modes to enhance your experience:
+
+- **Classic Mode** (Available): Traditional snake game with regular apples only
+- **More Fruits Mode** (Coming Soon): Features multiple fruit varieties with different point values
+- **Poisoned Apple Mode** (Coming Soon): Adds deadly poisoned apples that end the game on contact
+
+Access game modes from the main menu by selecting "Game Modes".
 
 Controls
 ------------------------------

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -185,6 +185,19 @@ class ECSGameApp:
         """Create initial game entities using prefabs."""
         grid_size = self.world.board.cell_size
 
+        # create game mode singleton entity
+        from src.ecs.components.game_mode import GameMode, GameModeType
+
+        class GameModeEntity:
+            def __init__(self):
+                self.game_mode = GameMode(mode=GameModeType.CLASSIC)
+
+            def get_type(self):
+                return None  # singleton entity has no specific type
+
+        game_mode_entity = GameModeEntity()
+        self.world.registry.add(game_mode_entity)
+
         # create snake at center of board
         _ = create_snake(
             world=self.world,

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -32,6 +32,7 @@ from src.ecs.prefabs.apple import create_apple
 from src.ecs.prefabs.obstacle_field import create_obstacles
 from src.game.scenes.scene_manager import SceneManager
 from src.game.scenes.menu import MenuScene
+from src.game.scenes.game_modes import GameModesScene
 from src.game.scenes.gameplay import GameplayScene
 from src.game.scenes.game_over import GameOverScene
 from src.game.scenes.settings import SettingsScene
@@ -144,6 +145,17 @@ class ECSGameApp:
             config=self.config,
         )
         self.scene_manager.register_scene("settings", settings_scene)
+
+        # Game modes scene
+        game_modes_scene = GameModesScene(
+            pygame_adapter=self.pygame_adapter,
+            renderer=self.renderer.view(),
+            width=self.config.initial_width,
+            height=self.config.initial_height,
+            assets=self.assets,
+            settings=self.settings,
+        )
+        self.scene_manager.register_scene("game_modes", game_modes_scene)
 
         # Gameplay scene
         gameplay_scene = GameplayScene(

--- a/src/ecs/components/edible.py
+++ b/src/ecs/components/edible.py
@@ -26,9 +26,12 @@ from dataclasses import dataclass
 class Edible:
     """Marks an entity as edible by the snake.
 
-    Contains properties for scoring and growth when consumed.
-    Used by: Apple
+    Contains properties for scoring, growth, and speed effects when consumed.
+    Used by: Apple, Grape, Orange
     """
 
-    points: int = 10  # Hoy many points earned by fruit
+    points: int = 10  # how many points earned by fruit
     growth: int = 1  # how many segments to add to snake by fruit
+    speed_modifier: float = (
+        1.1  # speed multiplier when eaten (e.g., 1.1 = +10%, 0.8 = -20%)
+    )

--- a/src/ecs/components/game_mode.py
+++ b/src/ecs/components/game_mode.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Game mode component for tracking selected game mode."""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class GameModeType(Enum):
+    """Enum for different game modes."""
+
+    CLASSIC = auto()  # default mode with only apples
+    MORE_FRUITS = auto()  # mode with multiple fruit varieties
+    POISONED_APPLE = auto()  # mode with deadly poisoned apples
+
+
+@dataclass
+class GameMode:
+    """Component for tracking the selected game mode.
+
+    This component is attached to the game singleton entity to track
+    which game mode is currently selected.
+
+    Used by: Game entity (singleton)
+    Read by: Gameplay systems (spawn, collision, etc.)
+    Written by: MenuScene, GameModesScene
+    """
+
+    mode: GameModeType = GameModeType.CLASSIC
+    available: bool = True  # whether this mode is available to play

--- a/src/ecs/components/game_state.py
+++ b/src/ecs/components/game_state.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
-#   Copyright (c) 2024, Leticia Neves
 #
 #   This file is part of Naja.
 #
@@ -40,3 +39,6 @@ class GameState:
     game_over: bool = False
     death_reason: str = ""
     next_scene: Optional[str] = None
+    settings_menu_open: bool = False
+    settings_selected_index: int = 0
+    settings_menu_item_count: int = 0  # total items including "Return to Menu"

--- a/src/ecs/components/poisoned.py
+++ b/src/ecs/components/poisoned.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Poisoned component for marking deadly apples."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Poisoned:
+    """Marks an entity as poisoned/deadly.
+
+    When an entity with this component is eaten by the snake,
+    the game ends immediately.
+
+    Used by: Poisoned Apple
+    """
+
+    deadly: bool = True  # whether contact is fatal

--- a/src/ecs/prefabs/grape.py
+++ b/src/ecs/prefabs/grape.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-#
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
 #   This file is part of Naja.
 #
 #   Naja is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Apple entity prefab factory."""
+"""Grape entity prefab factory."""
 
 from typing import Optional
 
@@ -29,45 +29,46 @@ from src.ecs.components.renderable import Renderable
 from src.core.types.color import Color
 
 
-def create_apple(
+def create_grape(
     world: World,
     x: int,
     y: int,
     grid_size: int,
     color: Optional[tuple[int, int, int]] = None,
-    points: int = 10,
-    growth: int = 1,
 ) -> int:
-    """Create an apple entity at the specified position.
+    """Create a grape entity at the specified position.
+
+    Grapes grow snake by 1 segment and decrease speed by 20% for strategic control.
 
     Args:
         world: ECS world to create entity in
         x: X position in pixels (grid-aligned)
         y: Y position in pixels (grid-aligned)
         grid_size: Size of each grid cell in pixels
-        color: RGB color for apple (default: red)
-        points: Points awarded when eaten
-        growth: Number of segments to add to snake when eaten
+        color: RGB color for grape (default: purple)
 
     Returns:
-        int: Entity ID of created apple
+        int: Entity ID of created grape
 
     Example:
-        >>> apple_id = create_apple(world, x=100, y=100, grid_size=20)
-        >>> apple = world.registry.get(apple_id)
-        >>> apple.position.x, apple.position.y
-        (100, 100)
+        >>> grape_id = create_grape(world, x=100, y=100, grid_size=20)
+        >>> grape = world.registry.get(grape_id)
+        >>> grape.edible.speed_modifier
+        0.8
     """
     # default color if not specified
     if color is None:
-        color = (170, 0, 0)  # red
+        color = (128, 0, 128)  # purple
 
-    # create apple entity with required components
-    apple = Apple(
+    # create grape entity with required components
+    # using Apple class as base (all fruits share same structure)
+    grape = Apple(
         position=Position(x=x, y=y, prev_x=x, prev_y=y),
         edible=Edible(
-            points=points, growth=growth, speed_modifier=1.1
-        ),  # apples speed up by 10%
+            points=10,
+            growth=1,
+            speed_modifier=0.8,  # slows down by 20%
+        ),
         renderable=Renderable(
             shape="circle",
             color=Color(color[0], color[1], color[2]),
@@ -76,5 +77,5 @@ def create_apple(
     )
 
     # register entity with world and return ID
-    entity_id = world.registry.add(apple)
+    entity_id = world.registry.add(grape)
     return entity_id

--- a/src/ecs/prefabs/orange.py
+++ b/src/ecs/prefabs/orange.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-#
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
 #   This file is part of Naja.
 #
 #   Naja is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Apple entity prefab factory."""
+"""Orange entity prefab factory."""
 
 from typing import Optional
 
@@ -29,45 +29,46 @@ from src.ecs.components.renderable import Renderable
 from src.core.types.color import Color
 
 
-def create_apple(
+def create_orange(
     world: World,
     x: int,
     y: int,
     grid_size: int,
     color: Optional[tuple[int, int, int]] = None,
-    points: int = 10,
-    growth: int = 1,
 ) -> int:
-    """Create an apple entity at the specified position.
+    """Create an orange entity at the specified position.
+
+    Oranges grow snake by 2 segments and increase speed.
 
     Args:
         world: ECS world to create entity in
         x: X position in pixels (grid-aligned)
         y: Y position in pixels (grid-aligned)
         grid_size: Size of each grid cell in pixels
-        color: RGB color for apple (default: red)
-        points: Points awarded when eaten
-        growth: Number of segments to add to snake when eaten
+        color: RGB color for orange (default: orange)
 
     Returns:
-        int: Entity ID of created apple
+        int: Entity ID of created orange
 
     Example:
-        >>> apple_id = create_apple(world, x=100, y=100, grid_size=20)
-        >>> apple = world.registry.get(apple_id)
-        >>> apple.position.x, apple.position.y
-        (100, 100)
+        >>> orange_id = create_orange(world, x=100, y=100, grid_size=20)
+        >>> orange = world.registry.get(orange_id)
+        >>> orange.edible.growth
+        2
     """
     # default color if not specified
     if color is None:
-        color = (170, 0, 0)  # red
+        color = (255, 165, 0)  # orange
 
-    # create apple entity with required components
-    apple = Apple(
+    # create orange entity with required components
+    # using Apple class as base (all fruits share same structure)
+    orange = Apple(
         position=Position(x=x, y=y, prev_x=x, prev_y=y),
         edible=Edible(
-            points=points, growth=growth, speed_modifier=1.1
-        ),  # apples speed up by 10%
+            points=10,
+            growth=2,  # grows by 2 segments!
+            speed_modifier=1.1,  # speeds up by 10%
+        ),
         renderable=Renderable(
             shape="circle",
             color=Color(color[0], color[1], color[2]),
@@ -76,5 +77,5 @@ def create_apple(
     )
 
     # register entity with world and return ID
-    entity_id = world.registry.add(apple)
+    entity_id = world.registry.add(orange)
     return entity_id

--- a/src/ecs/prefabs/poisoned_apple.py
+++ b/src/ecs/prefabs/poisoned_apple.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Poisoned apple entity prefab factory."""
+
+from typing import Optional
+
+from src.ecs.world import World
+from src.ecs.entities.apple import Apple
+from src.ecs.components.position import Position
+from src.ecs.components.edible import Edible
+from src.ecs.components.poisoned import Poisoned
+from src.ecs.components.renderable import Renderable
+from src.core.types.color import Color
+
+
+def create_poisoned_apple(
+    world: World,
+    x: int,
+    y: int,
+    grid_size: int,
+    color: Optional[tuple[int, int, int]] = None,
+) -> int:
+    """Create a poisoned apple entity at the specified position.
+
+    Poisoned apples are deadly - eating them ends the game immediately.
+    They appear as dark purple/black apples.
+
+    Args:
+        world: ECS world to create entity in
+        x: X position in pixels (grid-aligned)
+        y: Y position in pixels (grid-aligned)
+        grid_size: Size of each grid cell in pixels
+        color: RGB color for poisoned apple (default: dark purple)
+
+    Returns:
+        int: Entity ID of created poisoned apple
+
+    Example:
+        >>> poisoned_id = create_poisoned_apple(world, x=100, y=100, grid_size=20)
+        >>> poisoned = world.registry.get(poisoned_id)
+        >>> poisoned.poisoned.deadly
+        True
+    """
+    # default color if not specified - dark purple/black
+    if color is None:
+        color = (75, 0, 130)  # dark purple (indigo)
+
+    # create poisoned apple entity with required components
+    # using Apple class as base (all apples share same structure)
+    poisoned_apple = Apple(
+        position=Position(x=x, y=y, prev_x=x, prev_y=y),
+        edible=Edible(
+            points=0,  # no points for poisoned apples
+            growth=0,  # no growth - just death
+            speed_modifier=1.0,  # no speed change
+        ),
+        renderable=Renderable(
+            shape="circle",
+            color=Color(color[0], color[1], color[2]),
+            size=grid_size,
+        ),
+    )
+
+    # add poisoned component to mark as deadly
+    poisoned_apple.poisoned = Poisoned(deadly=True)
+
+    # register entity with world and return ID
+    entity_id = world.registry.add(poisoned_apple)
+    return entity_id

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -291,9 +291,16 @@ class CollisionSystem(BaseSystem):
                     if self._audio_service:
                         self._audio_service.play_sound("assets/sound/eat.flac")
 
-                    # grow snake
+                    # get edible properties
+                    growth = 1
+                    speed_modifier = 1.1
+                    if hasattr(apple, "edible"):
+                        growth = apple.edible.growth
+                        speed_modifier = apple.edible.speed_modifier
+
+                    # grow snake by the fruit's growth amount
                     if hasattr(snake, "body"):
-                        snake.body.size += 1
+                        snake.body.size += growth
 
                     # increment score
                     score_entities = world.registry.query_by_component("score")
@@ -302,7 +309,7 @@ class CollisionSystem(BaseSystem):
                         if hasattr(score_entity, "score"):
                             score_entity.score.current += 1
 
-                    # increase speed by 10%, respect max_speed
+                    # apply speed modifier from fruit, respect max_speed
                     if hasattr(snake, "velocity"):
                         current_speed = snake.velocity.speed
                         max_speed = (
@@ -310,7 +317,14 @@ class CollisionSystem(BaseSystem):
                             if self._settings
                             else 20.0
                         )
-                        new_speed = min(current_speed * 1.1, max_speed)
+                        new_speed = min(current_speed * speed_modifier, max_speed)
+                        # ensure speed doesn't go below initial speed
+                        initial_speed = (
+                            float(self._settings.get("initial_speed"))
+                            if self._settings
+                            else 4.0
+                        )
+                        new_speed = max(new_speed, initial_speed)
                         snake.velocity.speed = new_speed
 
                     # remove eaten apple

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
-#   Copyright (c) 2024, Leticia Neves
 #
 #   This file is part of Naja.
 #

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -287,6 +287,13 @@ class CollisionSystem(BaseSystem):
                 if head_x == apple.position.x and head_y == apple.position.y:
                     print(f"APPLE EATEN: head=({head_x},{head_y})")
 
+                    # check if apple is poisoned - instant death!
+                    if hasattr(apple, "poisoned") and apple.poisoned.deadly:
+                        print("POISONED APPLE! Game Over!")
+                        world.registry.remove(entity_id)
+                        self._handle_death(world, "poisoned apple")
+                        return
+
                     # play apple eating sound
                     if self._audio_service:
                         self._audio_service.play_sound("assets/sound/eat.flac")

--- a/src/ecs/systems/fruit_spawn.py
+++ b/src/ecs/systems/fruit_spawn.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Multi-fruit spawn system for More Fruits game mode.
+
+This system spawns different fruit types with weighted probabilities:
+- Apple (Red): 65% spawn rate, +1 segment, speed up
+- Grape (Purple): 25% spawn rate, +1 segment, slow down
+- Orange: 10% spawn rate, +2 segments, speed up
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+from src.ecs.systems.base_system import BaseSystem
+from src.ecs.world import World
+from src.ecs.entities.entity import EntityType
+from src.ecs.prefabs.apple import create_apple
+from src.ecs.prefabs.grape import create_grape
+from src.ecs.prefabs.orange import create_orange
+
+
+class FruitSpawnSystem(BaseSystem):
+    """System for spawning multiple fruit types with weighted probabilities.
+
+    Reads: AppleConfig (desired count), Apple entities (current count)
+    Writes: Creates new fruit entities (apple, grape, orange) as needed
+
+    Responsibilities:
+    - Count current number of fruits in the world
+    - Spawn new fruits if count is below desired
+    - Use weighted random selection for fruit type
+    - Find valid spawn positions (avoiding snake, obstacles, other fruits)
+
+    Spawn Probabilities:
+    - Apple: 65% (0.00 - 0.65)
+    - Grape: 25% (0.65 - 0.90)
+    - Orange: 10% (0.90 - 1.00)
+    """
+
+    def __init__(self, max_spawn_attempts: int = 1000):
+        """Initialize the FruitSpawnSystem.
+
+        Args:
+            max_spawn_attempts: Maximum attempts to find a valid spawn position
+        """
+        self._max_spawn_attempts = max_spawn_attempts
+
+    def update(self, world: World) -> None:
+        """Check fruit count and spawn new fruits if needed.
+
+        Args:
+            world: ECS world containing entities and components
+        """
+        # get desired fruit count from config
+        desired_count = self._get_desired_fruit_count(world)
+
+        if desired_count <= 0:
+            return
+
+        # count current fruits (apples represent all fruit types)
+        current_fruits = world.registry.query_by_type(EntityType.APPLE)
+        current_count = len(current_fruits)
+
+        # spawn new fruits if we're below desired count
+        fruits_to_spawn = desired_count - current_count
+
+        if fruits_to_spawn > 0:
+            grid_size = world.board.cell_size
+
+            for _ in range(fruits_to_spawn):
+                position = self._find_valid_position(world)
+                if position:
+                    x, y = position
+                    self._spawn_random_fruit(world, x, y, grid_size)
+
+    def _spawn_random_fruit(self, world: World, x: int, y: int, grid_size: int) -> None:
+        """Spawn a random fruit type based on weighted probabilities.
+
+        Probabilities:
+        - Apple: 65% (0.00 - 0.65)
+        - Grape: 25% (0.65 - 0.90)
+        - Orange: 10% (0.90 - 1.00)
+
+        Args:
+            world: ECS world
+            x: X position in grid coordinates
+            y: Y position in grid coordinates
+            grid_size: Size of each grid cell
+        """
+        rand = random.random()
+
+        if rand < 0.65:
+            # apple - 65% chance
+            create_apple(world, x=x, y=y, grid_size=grid_size, color=None)
+        elif rand < 0.90:
+            # grape - 25% chance
+            create_grape(world, x=x, y=y, grid_size=grid_size, color=None)
+        else:
+            # orange - 10% chance
+            create_orange(world, x=x, y=y, grid_size=grid_size, color=None)
+
+    def _get_desired_fruit_count(self, world: World) -> int:
+        """Get the desired number of fruits from AppleConfig component.
+
+        Args:
+            world: ECS world
+
+        Returns:
+            Desired fruit count, or 1 if no config found
+        """
+        # query for entities with AppleConfig component
+        config_entities = world.registry.query_by_component("apple_config")
+
+        if config_entities:
+            config_entity = list(config_entities.values())[0]
+            if hasattr(config_entity, "apple_config"):
+                return config_entity.apple_config.desired_count
+
+        return 1  # default to 1 fruit
+
+    def _find_valid_position(self, world: World) -> Optional[tuple[int, int]]:
+        """Find a valid position to spawn a fruit.
+
+        A valid position is one that:
+        - Is within board bounds
+        - Doesn't overlap with snake head
+        - Doesn't overlap with snake body segments
+        - Doesn't overlap with obstacles
+        - Doesn't overlap with existing fruits
+
+        Args:
+            world: ECS world
+
+        Returns:
+            (x, y) tuple if valid position found, None otherwise
+        """
+        board = world.board
+
+        # get occupied positions
+        occupied = self._get_occupied_positions(world)
+
+        # try to find a valid position
+        for _ in range(self._max_spawn_attempts):
+            x = random.randint(0, board.width - 1)
+            y = random.randint(0, board.height - 1)
+
+            if (x, y) not in occupied:
+                return (x, y)
+
+        # if we couldn't find a position after max attempts, return None
+        return None
+
+    def _get_occupied_positions(self, world: World) -> set[tuple[int, int]]:
+        """Get all positions currently occupied by game entities.
+
+        Args:
+            world: ECS world
+
+        Returns:
+            Set of (x, y) tuples representing occupied positions
+        """
+        occupied = set()
+
+        # get snake positions
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for _, snake in snakes.items():
+            if hasattr(snake, "position"):
+                # add head position
+                occupied.add((snake.position.x, snake.position.y))
+
+                # add body segments
+                if hasattr(snake, "body"):
+                    for segment in snake.body.segments:
+                        occupied.add((segment.x, segment.y))
+
+        # get obstacle positions
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        for _, obstacle in obstacles.items():
+            if hasattr(obstacle, "position"):
+                occupied.add((obstacle.position.x, obstacle.position.y))
+
+        # get existing fruit positions (all apples are fruits)
+        fruits = world.registry.query_by_type(EntityType.APPLE)
+        for _, fruit in fruits.items():
+            if hasattr(fruit, "position"):
+                occupied.add((fruit.position.x, fruit.position.y))
+
+        return occupied

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -294,9 +294,19 @@ class InputSystem(BaseSystem):
             field_key: The key of the field that was changed
         """
         if field_key == "background_music":
-            # only control background music
+            # control background music
             if self._settings.get("background_music"):
+                # try to unpause first
                 pygame.mixer.music.unpause()
+                # if music isn't playing, reload and start it
+                if not pygame.mixer.music.get_busy():
+                    try:
+                        pygame.mixer.music.load(
+                            "assets/sound/BoxCat_Games_CPU_Talk.ogg"
+                        )
+                        pygame.mixer.music.play(-1)
+                    except Exception:
+                        pass
             else:
                 pygame.mixer.music.pause()
         elif field_key == "sound_effects":

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
-#   Copyright (c) 2024, Leticia Neves
 #
 #   This file is part of Naja.
 #
@@ -100,6 +99,12 @@ class InputSystem(BaseSystem):
             world: ECS world
             key: Pygame key constant
         """
+        # check if settings menu is open first
+        game_state = self._get_game_state(world)
+        if game_state and game_state.settings_menu_open:
+            self._handle_settings_menu_input(world, key)
+            return
+
         # get current direction for 180° turn prevention
         current_dx, current_dy = self._get_current_direction(world)
 
@@ -117,8 +122,8 @@ class InputSystem(BaseSystem):
             self._handle_quit(world)
         elif key == pygame.K_p:
             self._handle_pause(world)
-        # elif key == pygame.K_m:
-        #     self._handle_menu(world)  # disabled: removed ability to open settings from gameplay
+        elif key in (pygame.K_ESCAPE, pygame.K_m):
+            self._handle_open_settings(world)
         elif key == pygame.K_n:
             self._handle_music_toggle()
         elif key == pygame.K_c:
@@ -205,17 +210,101 @@ class InputSystem(BaseSystem):
         if game_state:
             game_state.paused = not game_state.paused
 
-    # disabled: removed ability to open settings from gameplay
-    # def _handle_menu(self, world: World) -> None:
-    #     """Handle menu key press by pausing and setting next_scene.
-    #
-    #     Args:
-    #         world: ECS world
-    #     """
-    #     game_state = self._get_game_state(world)
-    #     if game_state:
-    #         game_state.paused = True
-    #         game_state.next_scene = "settings"
+    def _handle_open_settings(self, world: World) -> None:
+        """Handle settings menu open key press (ESC or M).
+
+        Opens in-game settings overlay and pauses the game.
+
+        Args:
+            world: ECS world
+        """
+        game_state = self._get_game_state(world)
+        if game_state:
+            # calculate total menu items (settings + "Return to Menu" option)
+            in_game_fields = (
+                self._settings.get_in_game_menu_fields() if self._settings else []
+            )
+            game_state.settings_menu_item_count = (
+                len(in_game_fields) + 1
+            )  # +1 for "Return to Menu"
+            game_state.settings_menu_open = True
+            game_state.paused = True
+            game_state.settings_selected_index = 0
+
+    def _handle_settings_menu_input(self, world: World, key: int) -> None:
+        """Handle input when settings menu is open.
+
+        Args:
+            world: ECS world
+            key: Pygame key constant
+        """
+        game_state = self._get_game_state(world)
+        if not game_state or not self._settings:
+            return
+
+        # use only in-game adjustable fields (no reset required)
+        menu_fields = self._settings.get_in_game_menu_fields()
+        total_items = len(menu_fields) + 1  # +1 for "Return to Menu" option
+        return_to_menu_index = len(menu_fields)  # last item
+
+        # handle ESC to close settings
+        if key == pygame.K_ESCAPE:
+            game_state.settings_menu_open = False
+            game_state.paused = False
+        # handle RETURN to activate selected item
+        elif key == pygame.K_RETURN:
+            if game_state.settings_selected_index == return_to_menu_index:
+                # "Return to Menu" selected
+                game_state.settings_menu_open = False
+                game_state.paused = False
+                game_state.next_scene = "menu"
+            else:
+                # close settings and resume game
+                game_state.settings_menu_open = False
+                game_state.paused = False
+        # navigate down
+        elif key in (pygame.K_DOWN, pygame.K_s):
+            game_state.settings_selected_index = (
+                game_state.settings_selected_index + 1
+            ) % total_items
+        # navigate up
+        elif key in (pygame.K_UP, pygame.K_w):
+            game_state.settings_selected_index = (
+                game_state.settings_selected_index - 1
+            ) % total_items
+        # adjust setting left/right (only for actual settings, not "Return to Menu")
+        elif key in (pygame.K_LEFT, pygame.K_a):
+            if game_state.settings_selected_index < len(menu_fields):
+                field = menu_fields[game_state.settings_selected_index]
+                self._settings.step_setting(field, -1)
+                self._apply_audio_setting_if_changed(field["key"])
+        elif key in (pygame.K_RIGHT, pygame.K_d):
+            if game_state.settings_selected_index < len(menu_fields):
+                field = menu_fields[game_state.settings_selected_index]
+                self._settings.step_setting(field, +1)
+                self._apply_audio_setting_if_changed(field["key"])
+        # randomize colors
+        elif key == pygame.K_c:
+            self._handle_palette_randomize()
+
+    def _apply_audio_setting_if_changed(self, field_key: str) -> None:
+        """Apply audio settings immediately when changed.
+
+        Args:
+            field_key: The key of the field that was changed
+        """
+        if field_key == "background_music":
+            # only control background music
+            if self._settings.get("background_music"):
+                pygame.mixer.music.unpause()
+            else:
+                pygame.mixer.music.pause()
+        elif field_key == "sound_effects":
+            # control all sound effect channels
+            if self._settings.get("sound_effects"):
+                pygame.mixer.unpause()
+            else:
+                pygame.mixer.pause()
 
     def _handle_music_toggle(self) -> None:
         """Handle audio toggle key press.

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""OverlayRenderSystem - renders pause and settings overlays.
+
+This system follows ECS Single Responsibility Principle by handling ONLY
+overlay rendering (pause screen, settings menu) on top of the game.
+"""
+
+import pygame
+from src.ecs.systems.base_system import BaseSystem
+from src.ecs.world import World
+from src.core.rendering.pygame_surface_renderer import RenderEnqueue
+from src.core.types.color import Color
+from src.game import constants
+
+
+class OverlayRenderSystem(BaseSystem):
+    """System responsible for rendering game overlays.
+
+    Responsibilities:
+    - Render pause overlay (when paused)
+    - Render settings overlay (when settings menu is open)
+
+    NOT responsible for:
+    - Basic HUD rendering (use UIRenderSystem)
+    - Game world rendering (use BoardRenderSystem)
+    """
+
+    def __init__(self, renderer: RenderEnqueue, settings=None, config=None):
+        """Initialize the OverlayRenderSystem.
+
+        Args:
+            renderer: RenderEnqueue view to queue draw commands
+            settings: Optional GameSettings instance for accessing settings
+            config: Game config for calculating grid size
+        """
+        self._renderer = renderer
+        self._settings = settings
+        self._config = config
+
+    def draw_pause_overlay(self, surface_width: int, surface_height: int) -> None:
+        """Draw pause overlay with semi-transparent background and text.
+
+        Args:
+            surface_width: Width of the surface
+            surface_height: Height of the surface
+        """
+        try:
+            # create semi-transparent overlay
+            overlay = pygame.Surface((surface_width, surface_height))
+            overlay.set_alpha(128)  # 50% transparent
+            overlay.fill(Color.from_hex(constants.ARENA_COLOR).to_tuple())
+            self._renderer.blit(overlay, (0, 0))
+
+            # render "PAUSED" text
+            font_size = int(surface_width / 10)
+            font_path = "assets/font/GetVoIP-Grotesque.ttf"
+
+            try:
+                pause_font = pygame.font.Font(font_path, font_size)
+            except Exception:
+                pause_font = pygame.font.Font(None, font_size)
+
+            pause_text = pause_font.render(
+                "PAUSED", True, Color.from_hex(constants.SCORE_COLOR).to_tuple()
+            )
+            pause_rect = pause_text.get_rect()
+            pause_rect.center = (surface_width // 2, surface_height // 2)
+
+            # blit to screen
+            self._renderer.blit(pause_text, pause_rect)
+
+            # render hint text below
+            hint_font_size = int(surface_width / 30)
+            try:
+                hint_font = pygame.font.Font(font_path, hint_font_size)
+            except Exception:
+                hint_font = pygame.font.Font(None, hint_font_size)
+
+            hint_text = hint_font.render(
+                "Press P to resume or ESC/M for settings",
+                True,
+                Color.from_hex(constants.MESSAGE_COLOR).to_tuple(),
+            )
+            hint_rect = hint_text.get_rect()
+            hint_rect.midtop = (surface_width // 2, pause_rect.bottom + 20)
+
+            # blit hint
+            self._renderer.blit(hint_text, hint_rect)
+
+        except Exception:
+            # silently fail if rendering fails
+            pass
+
+    def draw_settings_overlay(
+        self,
+        surface_width: int,
+        surface_height: int,
+        selected_index: int,
+    ) -> None:
+        """Draw settings overlay with semi-transparent background and settings menu.
+
+        Args:
+            surface_width: Width of the surface
+            surface_height: Height of the surface
+            selected_index: Currently selected setting index
+        """
+        if not self._settings:
+            return
+
+        try:
+            # create semi-transparent overlay
+            overlay = pygame.Surface((surface_width, surface_height))
+            overlay.set_alpha(200)  # more opaque than pause
+            overlay.fill(Color.from_hex(constants.ARENA_COLOR).to_tuple())
+            self._renderer.blit(overlay, (0, 0))
+
+            # draw title
+            self._draw_settings_title(surface_width, surface_height)
+
+            # draw settings items
+            self._draw_settings_items(surface_width, surface_height, selected_index)
+
+            # draw hint footer
+            self._draw_settings_hint(surface_width, surface_height)
+
+        except Exception:
+            # silently fail if rendering fails
+            pass
+
+    def _draw_settings_title(self, surface_width: int, surface_height: int) -> None:
+        """Draw settings menu title."""
+        font_path = "assets/font/GetVoIP-Grotesque.ttf"
+        title_font_size = int(surface_width / 12)
+        try:
+            title_font = pygame.font.Font(font_path, title_font_size)
+        except Exception:
+            title_font = pygame.font.Font(None, title_font_size)
+
+        title_text = title_font.render(
+            "Settings", True, Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
+        )
+        title_rect = title_text.get_rect(
+            center=(surface_width / 2, surface_height / 10)
+        )
+        self._renderer.blit(title_text, title_rect)
+
+    def _draw_settings_items(
+        self, surface_width: int, surface_height: int, selected_index: int
+    ) -> None:
+        """Draw individual settings items."""
+        font_path = "assets/font/GetVoIP-Grotesque.ttf"
+
+        # spacing and scroll parameters
+        row_h = int(surface_height * 0.06)
+        visible_rows = int(surface_height * 0.70 // row_h)
+        top_index = max(0, selected_index - visible_rows + 3)
+        padding_y = int(surface_height * 0.22)
+
+        # get in-game adjustable settings
+        menu_fields = self._settings.get_in_game_menu_fields()
+        return_to_menu_index = len(menu_fields)
+
+        item_font_size = int(surface_width / 30)
+        try:
+            item_font = pygame.font.Font(font_path, item_font_size)
+        except Exception:
+            item_font = pygame.font.Font(None, item_font_size)
+
+        # draw settings items
+        for draw_i, field_i in enumerate(range(top_index, len(menu_fields))):
+            if draw_i >= visible_rows:
+                break
+            f = menu_fields[field_i]
+            val = self._settings.get(f["key"])
+
+            # calculate current grid size for display
+            current_grid_size = 20  # default fallback
+            if self._config:
+                desired_cells = max(10, int(self._settings.get("cells_per_side")))
+                current_grid_size = self._config.get_optimal_grid_size(desired_cells)
+
+            formatted_val = self._settings.format_setting_value(
+                f,
+                val,
+                surface_width,
+                current_grid_size,
+            )
+
+            # render text with highlighting for selected item
+            text_color = (
+                Color.from_hex(constants.SCORE_COLOR).to_tuple()
+                if field_i == selected_index
+                else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
+            )
+            text = item_font.render(f"{f['label']}: {formatted_val}", True, text_color)
+            rect = text.get_rect()
+            rect.left = int(surface_width * 0.10)
+            rect.top = padding_y + draw_i * row_h
+            self._renderer.blit(text, rect)
+
+        # draw "Return to Menu" option
+        return_draw_i = len(menu_fields) - top_index
+        if 0 <= return_draw_i < visible_rows:
+            text_color = (
+                Color.from_hex(constants.SCORE_COLOR).to_tuple()
+                if selected_index == return_to_menu_index
+                else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
+            )
+            separator_top = padding_y + return_draw_i * row_h
+            # add some spacing before the option
+            return_text = item_font.render("Return to Main Menu", True, text_color)
+            rect = return_text.get_rect()
+            rect.left = int(surface_width * 0.10)
+            rect.top = separator_top + int(row_h * 0.5)  # add spacing
+            self._renderer.blit(return_text, rect)
+
+    def _draw_settings_hint(self, surface_width: int, surface_height: int) -> None:
+        """Draw settings menu hint footer."""
+        font_path = "assets/font/GetVoIP-Grotesque.ttf"
+        hint_text = "[A/D] change   [W/S] navigate   [Enter] select   [Esc] back   [C] random colors"
+        hint_font_size = int(surface_width / 50)
+        try:
+            hint_font = pygame.font.Font(font_path, hint_font_size)
+        except Exception:
+            hint_font = pygame.font.Font(None, hint_font_size)
+
+        hint_surf = hint_font.render(
+            hint_text, True, Color.from_hex(constants.GRID_COLOR).to_tuple()
+        )
+        hint_rect = hint_surf.get_rect(
+            center=(surface_width / 2, surface_height * 0.95)
+        )
+        self._renderer.blit(hint_surf, hint_rect)
+
+    def update(self, world: World) -> None:
+        """Update method required by BaseSystem.
+
+        Renders overlays based on game state.
+        Note: This system is called manually from GameplayScene,
+        not in the regular system update loop.
+
+        Args:
+            world: Game world
+        """
+        pass  # overlays are drawn manually by GameplayScene

--- a/src/ecs/systems/poisoned_apple_spawn.py
+++ b/src/ecs/systems/poisoned_apple_spawn.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Poisoned apple spawn system for Poisoned Apple game mode.
+
+This system maintains:
+- 1 regular apple (red) - always present, safe to eat
+- 0-1 poisoned apple (dark purple) - occasionally spawns, deadly!
+
+The poisoned apple spawns randomly with configurable probability.
+When a new poisoned apple spawns, the old one is removed.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+from src.ecs.systems.base_system import BaseSystem
+from src.ecs.world import World
+from src.ecs.entities.entity import EntityType
+from src.ecs.prefabs.apple import create_apple
+from src.ecs.prefabs.poisoned_apple import create_poisoned_apple
+
+
+class PoisonedAppleSpawnSystem(BaseSystem):
+    """System for spawning regular and poisoned apples.
+
+    Reads: AppleConfig (desired count), Apple entities (current count)
+    Writes: Creates new apple entities (regular or poisoned) as needed
+
+    Responsibilities:
+    - Maintain exactly 1 regular apple on the board
+    - Occasionally spawn 1 poisoned apple (based on probability)
+    - Remove old poisoned apple when spawning a new one
+    - Find valid spawn positions (avoiding snake, obstacles, other apples)
+
+    Strategy:
+    - Regular apple is always present (player can always progress)
+    - Poisoned apple spawns with configurable probability per update
+    - Only 1 poisoned apple exists at a time
+    """
+
+    def __init__(
+        self,
+        max_spawn_attempts: int = 1000,
+        poison_spawn_chance: float = 0.01,
+    ):
+        """Initialize the PoisonedAppleSpawnSystem.
+
+        Args:
+            max_spawn_attempts: Maximum attempts to find a valid spawn position
+            poison_spawn_chance: Probability per update of spawning poisoned apple
+                                 (default 0.01 = 1% chance per frame)
+        """
+        self._max_spawn_attempts = max_spawn_attempts
+        self._poison_spawn_chance = poison_spawn_chance
+
+    def update(self, world: World) -> None:
+        """Maintain regular apple and occasionally spawn poisoned apple.
+
+        Args:
+            world: ECS world containing entities and components
+        """
+        grid_size = world.board.cell_size
+
+        # separate regular and poisoned apples
+        regular_apples = []
+        poisoned_apples = []
+
+        all_apples = world.registry.query_by_type(EntityType.APPLE)
+        for entity_id, apple in all_apples.items():
+            if hasattr(apple, "poisoned") and apple.poisoned.deadly:
+                poisoned_apples.append((entity_id, apple))
+            else:
+                regular_apples.append((entity_id, apple))
+
+        # ensure exactly 1 regular apple exists
+        if len(regular_apples) == 0:
+            position = self._find_valid_position(world)
+            if position:
+                x, y = position
+                create_apple(world, x=x, y=y, grid_size=grid_size, color=None)
+
+        # occasionally spawn poisoned apple
+        # only spawn if no poisoned apple exists and random chance succeeds
+        if len(poisoned_apples) == 0 and random.random() < self._poison_spawn_chance:
+            position = self._find_valid_position(world)
+            if position:
+                x, y = position
+                create_poisoned_apple(world, x=x, y=y, grid_size=grid_size, color=None)
+
+    def _find_valid_position(self, world: World) -> Optional[tuple[int, int]]:
+        """Find a valid position to spawn an apple.
+
+        A valid position is one that:
+        - Is within board bounds
+        - Doesn't overlap with snake head
+        - Doesn't overlap with snake body segments
+        - Doesn't overlap with obstacles
+        - Doesn't overlap with existing apples
+
+        Args:
+            world: ECS world
+
+        Returns:
+            (x, y) tuple if valid position found, None otherwise
+        """
+        board = world.board
+
+        # get occupied positions
+        occupied = self._get_occupied_positions(world)
+
+        # try to find a valid position
+        for _ in range(self._max_spawn_attempts):
+            x = random.randint(0, board.width - 1)
+            y = random.randint(0, board.height - 1)
+
+            if (x, y) not in occupied:
+                return (x, y)
+
+        # if we couldn't find a position after max attempts, return None
+        return None
+
+    def _get_occupied_positions(self, world: World) -> set[tuple[int, int]]:
+        """Get all positions currently occupied by game entities.
+
+        Args:
+            world: ECS world
+
+        Returns:
+            Set of (x, y) tuples representing occupied positions
+        """
+        occupied = set()
+
+        # get snake positions
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for _, snake in snakes.items():
+            if hasattr(snake, "position"):
+                # add head position
+                occupied.add((snake.position.x, snake.position.y))
+
+                # add body segments
+                if hasattr(snake, "body"):
+                    for segment in snake.body.segments:
+                        occupied.add((segment.x, segment.y))
+
+        # get obstacle positions
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        for _, obstacle in obstacles.items():
+            if hasattr(obstacle, "position"):
+                occupied.add((obstacle.position.x, obstacle.position.y))
+
+        # get existing apple positions (both regular and poisoned)
+        apples = world.registry.query_by_type(EntityType.APPLE)
+        for _, apple in apples.items():
+            if hasattr(apple, "position"):
+                occupied.add((apple.position.x, apple.position.y))
+
+        return occupied

--- a/src/ecs/systems/ui_render.py
+++ b/src/ecs/systems/ui_render.py
@@ -17,10 +17,10 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""UIRenderSystem - handles rendering of UI overlays (score, speed bar, music indicator).
+"""UIRenderSystem - handles rendering of basic HUD elements.
 
 This system follows ECS Single Responsibility Principle by handling ONLY
-UI element rendering on top of the game world.
+basic HUD element rendering (score, speed bar, music indicator).
 """
 
 import pygame
@@ -33,15 +33,15 @@ from src.game import constants
 
 
 class UIRenderSystem(BaseSystem):
-    """System responsible for rendering UI overlays.
+    """System responsible for rendering basic HUD elements.
 
     Responsibilities:
     - Render score counter
     - Render speed bar
     - Render music indicator
-    - Render pause overlay (when paused)
 
     NOT responsible for:
+    - Overlays (use OverlayRenderSystem)
     - Game world rendering (use BoardRenderSystem)
     - Entity rendering (use EntityRenderSystem, SnakeRenderSystem)
     """
@@ -64,12 +64,12 @@ class UIRenderSystem(BaseSystem):
             surface_width: Width of the surface
             surface_height: Height of the surface
         """
-        # Query score component from world
+        # query score component from world
         score_entities = world.registry.query_by_component("score")
         if not score_entities:
             return
 
-        # Get first score entity
+        # get first score entity
         score_entity = list(score_entities.values())[0]
         if not hasattr(score_entity, "score"):
             return
@@ -77,7 +77,7 @@ class UIRenderSystem(BaseSystem):
         current_score = score_entity.score.current
 
         try:
-            # Large font size
+            # large font size
             font_size = int(surface_width / 8)
             font_path = "assets/font/GetVoIP-Grotesque.ttf"
 
@@ -86,27 +86,27 @@ class UIRenderSystem(BaseSystem):
             except Exception:
                 score_font = pygame.font.Font(None, font_size)
 
-            # Get color from constants
+            # get color from constants
             score_color = Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
 
-            # Render score text
+            # render score text
             score_text = score_font.render(str(current_score), True, score_color)
 
-            # Make it translucent (~25% opaque)
+            # make it translucent (~25% opaque)
             score_text.set_alpha(64)
 
-            # Horizontal center; vertically near the top with margin
+            # horizontal center; vertically near the top with margin
             top_margin = getattr(
                 world.board, "cell_size", max(10, surface_height // 20)
             )
             score_rect = score_text.get_rect()
             score_rect.midtop = (surface_width // 2, top_margin)
 
-            # Blit to main surface
+            # blit to main surface
             self._renderer.blit(score_text, score_rect)
 
         except Exception:
-            # Silently fail if font loading or rendering fails
+            # silently fail if font loading or rendering fails
             pass
 
     def draw_speed_bar(
@@ -122,7 +122,7 @@ class UIRenderSystem(BaseSystem):
         if not self._settings:
             return
 
-        # Get speed settings
+        # get speed settings
         initial_speed = self._settings.get("initial_speed")
         max_speed = self._settings.get("max_speed")
         if initial_speed is None or max_speed is None:
@@ -131,7 +131,7 @@ class UIRenderSystem(BaseSystem):
         min_speed = float(initial_speed)
         max_speed = float(max_speed)
 
-        # Get current speed from snake
+        # get current speed from snake
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         current_speed = min_speed
         for _, snake in snakes.items():
@@ -139,20 +139,20 @@ class UIRenderSystem(BaseSystem):
                 current_speed = snake.velocity.speed
                 break
 
-        # Geometry
+        # geometry
         padding_x = int(surface_width * 0.02)
         padding_y = int(surface_height * 0.02)
         bar_width = int(surface_width * 0.25)
         bar_height = int(surface_height * 0.02)
         gap = 6
 
-        # Colors - bar changes from green (slow) to red (fast)
+        # colors - bar changes from green (slow) to red (fast)
         if max_speed > min_speed:
             ratio = (current_speed - min_speed) / (max_speed - min_speed)
         else:
             ratio = 0.0
         ratio = max(0.0, min(ratio, 1.0))
-        # Bar color changes from green (slow) to red (fast) - calculated dynamically
+        # bar color changes from green (slow) to red (fast) - calculated dynamically
         bar_color = (
             int(255 * ratio),
             int(255 * (1 - ratio)),
@@ -161,24 +161,24 @@ class UIRenderSystem(BaseSystem):
         border_color = Color.from_hex(constants.GRID_COLOR).to_tuple()
         text_color = Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
 
-        # Bar position
+        # bar position
         bar_x = padding_x
         bar_y = padding_y
 
-        # Create temporary surface for the speed bar
+        # create temporary surface for the speed bar
         bar_surface = pygame.Surface((bar_width, bar_height))
         bar_surface.fill(border_color)
 
-        # Draw filled portion
+        # draw filled portion
         filled_width = int(bar_width * ratio)
         if filled_width > 0:
             filled_rect = pygame.Rect(0, 0, filled_width, bar_height)
             pygame.draw.rect(bar_surface, bar_color, filled_rect)
 
-        # Blit bar to screen
+        # blit bar to screen
         self._renderer.blit(bar_surface, (bar_x, bar_y))
 
-        # Draw text label below
+        # draw text label below
         label_text = f"Speed: {current_speed:.1f}"
         font_size = int(surface_width / 50)
         font_path = "assets/font/GetVoIP-Grotesque.ttf"
@@ -192,7 +192,7 @@ class UIRenderSystem(BaseSystem):
         label_rect = label_surf.get_rect()
         label_rect.midtop = (bar_x + bar_width // 2, bar_y + bar_height + gap)
 
-        # Blit label
+        # blit label
         self._renderer.blit(label_surf, label_rect)
 
     def draw_music_indicator(
@@ -206,13 +206,13 @@ class UIRenderSystem(BaseSystem):
             music_on: Whether background music is currently enabled
         """
         try:
-            # Define dimensions
+            # define dimensions
             padding_x = int(surface_width * 0.02)
             padding_y = int(surface_height * 0.02)
             icon_size = int(surface_width / 25)
             gap = 4
 
-            # Load speaker sprites
+            # load speaker sprites
             try:
                 if music_on:
                     sprite = pygame.image.load("assets/sprites/speaker-on.png")
@@ -221,7 +221,7 @@ class UIRenderSystem(BaseSystem):
             except Exception:
                 sprite = None
 
-            # Render hint text - white when on, dim grid color when off
+            # render hint text - white when on, dim grid color when off
             hint_color = (
                 Color.from_hex(constants.SCORE_COLOR).to_tuple()
                 if music_on
@@ -239,217 +239,36 @@ class UIRenderSystem(BaseSystem):
             hint_surf = hint_font.render(hint_text, True, hint_color)
             hint_rect = hint_surf.get_rect()
 
-            # Calculate total widget height
+            # calculate total widget height
             total_widget_height = icon_size + gap + hint_rect.height
 
-            # Calculate positions (bottom-right corner)
+            # calculate positions (bottom-right corner)
             icon_x = surface_width - padding_x - icon_size
             icon_y = surface_height - padding_y - total_widget_height
 
-            # Scale and draw sprite
+            # scale and draw sprite
             if sprite is not None:
                 scaled_sprite = pygame.transform.scale(sprite, (icon_size, icon_size))
                 self._renderer.blit(scaled_sprite, (icon_x, icon_y))
 
-            # Position and draw text hint below the icon
+            # position and draw text hint below the icon
             hint_rect.centerx = icon_x + icon_size // 2
             hint_rect.top = icon_y + icon_size + gap
             self._renderer.blit(hint_surf, hint_rect)
 
         except Exception:
-            # Silently fail if sprite loading or rendering fails
-            pass
-
-    def draw_pause_overlay(self, surface_width: int, surface_height: int) -> None:
-        """Draw pause overlay with semi-transparent background and text.
-
-        Args:
-            surface_width: Width of the surface
-            surface_height: Height of the surface
-        """
-        try:
-            # Create semi-transparent overlay
-            overlay = pygame.Surface((surface_width, surface_height))
-            overlay.set_alpha(128)  # 50% transparent
-            overlay.fill(Color.from_hex(constants.ARENA_COLOR).to_tuple())
-            self._renderer.blit(overlay, (0, 0))
-
-            # Render "PAUSED" text
-            font_size = int(surface_width / 10)
-            font_path = "assets/font/GetVoIP-Grotesque.ttf"
-
-            try:
-                pause_font = pygame.font.Font(font_path, font_size)
-            except Exception:
-                pause_font = pygame.font.Font(None, font_size)
-
-            pause_text = pause_font.render(
-                "PAUSED", True, Color.from_hex(constants.SCORE_COLOR).to_tuple()
-            )
-            pause_rect = pause_text.get_rect()
-            pause_rect.center = (surface_width // 2, surface_height // 2)
-
-            # Blit to screen
-            self._renderer.blit(pause_text, pause_rect)
-
-            # Render hint text below
-            hint_font_size = int(surface_width / 30)
-            try:
-                hint_font = pygame.font.Font(font_path, hint_font_size)
-            except Exception:
-                hint_font = pygame.font.Font(None, hint_font_size)
-
-            hint_text = hint_font.render(
-                "Press P to resume or ESC/M for settings",
-                True,
-                Color.from_hex(constants.MESSAGE_COLOR).to_tuple(),
-            )
-            hint_rect = hint_text.get_rect()
-            hint_rect.midtop = (surface_width // 2, pause_rect.bottom + 20)
-
-            # Blit hint
-            self._renderer.blit(hint_text, hint_rect)
-
-        except Exception:
-            # Silently fail if rendering fails
-            pass
-
-    def draw_settings_overlay(
-        self,
-        surface_width: int,
-        surface_height: int,
-        selected_index: int,
-        config=None,
-    ) -> None:
-        """Draw settings overlay with semi-transparent background and settings menu.
-
-        Args:
-            surface_width: Width of the surface
-            surface_height: Height of the surface
-            selected_index: Currently selected setting index
-            config: Game config for calculating grid size
-        """
-        if not self._settings:
-            return
-
-        try:
-            # Create semi-transparent overlay
-            overlay = pygame.Surface((surface_width, surface_height))
-            overlay.set_alpha(200)  # More opaque than pause
-            overlay.fill(Color.from_hex(constants.ARENA_COLOR).to_tuple())
-            self._renderer.blit(overlay, (0, 0))
-
-            # Draw title
-            font_path = "assets/font/GetVoIP-Grotesque.ttf"
-            title_font_size = int(surface_width / 12)
-            try:
-                title_font = pygame.font.Font(font_path, title_font_size)
-            except Exception:
-                title_font = pygame.font.Font(None, title_font_size)
-
-            title_text = title_font.render(
-                "Settings", True, Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
-            )
-            title_rect = title_text.get_rect(
-                center=(surface_width / 2, surface_height / 10)
-            )
-            self._renderer.blit(title_text, title_rect)
-
-            # Spacing and scroll parameters
-            row_h = int(surface_height * 0.06)
-            visible_rows = int(surface_height * 0.70 // row_h)
-            top_index = max(0, selected_index - visible_rows + 3)
-            padding_y = int(surface_height * 0.22)
-
-            # Draw visible rows - only show in-game adjustable settings
-            menu_fields = self._settings.get_in_game_menu_fields()
-            return_to_menu_index = len(menu_fields)
-
-            item_font_size = int(surface_width / 30)
-            try:
-                item_font = pygame.font.Font(font_path, item_font_size)
-            except Exception:
-                item_font = pygame.font.Font(None, item_font_size)
-
-            # Draw settings items
-            for draw_i, field_i in enumerate(range(top_index, len(menu_fields))):
-                if draw_i >= visible_rows:
-                    break
-                f = menu_fields[field_i]
-                val = self._settings.get(f["key"])
-
-                # Calculate current grid size for display
-                current_grid_size = 20  # default fallback
-                if config:
-                    desired_cells = max(10, int(self._settings.get("cells_per_side")))
-                    current_grid_size = config.get_optimal_grid_size(desired_cells)
-
-                formatted_val = self._settings.format_setting_value(
-                    f,
-                    val,
-                    surface_width,
-                    current_grid_size,
-                )
-
-                # Render text with highlighting for selected item
-                text_color = (
-                    Color.from_hex(constants.SCORE_COLOR).to_tuple()
-                    if field_i == selected_index
-                    else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
-                )
-                text = item_font.render(
-                    f"{f['label']}: {formatted_val}", True, text_color
-                )
-                rect = text.get_rect()
-                rect.left = int(surface_width * 0.10)
-                rect.top = padding_y + draw_i * row_h
-                self._renderer.blit(text, rect)
-
-            # Draw "Return to Menu" option
-            return_draw_i = len(menu_fields) - top_index
-            if return_draw_i >= 0 and return_draw_i < visible_rows:
-                text_color = (
-                    Color.from_hex(constants.SCORE_COLOR).to_tuple()
-                    if selected_index == return_to_menu_index
-                    else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
-                )
-                separator_top = padding_y + return_draw_i * row_h
-                # add some spacing before the option
-                return_text = item_font.render("Return to Main Menu", True, text_color)
-                rect = return_text.get_rect()
-                rect.left = int(surface_width * 0.10)
-                rect.top = separator_top + int(row_h * 0.5)  # add spacing
-                self._renderer.blit(return_text, rect)
-
-            # Hint footer
-            hint_text = "[A/D] change   [W/S] navigate   [Enter] select   [Esc] back   [C] random colors"
-            hint_font_size = int(surface_width / 50)
-            try:
-                hint_font = pygame.font.Font(font_path, hint_font_size)
-            except Exception:
-                hint_font = pygame.font.Font(None, hint_font_size)
-
-            hint_surf = hint_font.render(
-                hint_text, True, Color.from_hex(constants.GRID_COLOR).to_tuple()
-            )
-            hint_rect = hint_surf.get_rect(
-                center=(surface_width / 2, surface_height * 0.95)
-            )
-            self._renderer.blit(hint_surf, hint_rect)
-
-        except Exception:
-            # Silently fail if rendering fails
+            # silently fail if sprite loading or rendering fails
             pass
 
     def update(self, world: World) -> None:
         """Update method required by BaseSystem.
 
-        Renders UI overlays on top of the game world.
+        Renders basic HUD elements on top of the game world.
 
         Args:
             world: Game world to render
         """
-        # Get surface dimensions
+        # get surface dimensions
         surface = pygame.display.get_surface()
         if not surface:
             return
@@ -457,11 +276,11 @@ class UIRenderSystem(BaseSystem):
         surface_width = surface.get_width()
         surface_height = surface.get_height()
 
-        # Draw UI elements
+        # draw UI elements
         self.draw_score(world, surface_width, surface_height)
         self.draw_speed_bar(world, surface_width, surface_height)
 
-        # Draw music indicator
+        # draw music indicator
         if self._settings:
             music_on = self._settings.get("background_music")
             self.draw_music_indicator(surface_width, surface_height, music_on)

--- a/src/ecs/systems/ui_render.py
+++ b/src/ecs/systems/ui_render.py
@@ -363,7 +363,6 @@ class UIRenderSystem(BaseSystem):
 
             # Draw visible rows - only show in-game adjustable settings
             menu_fields = self._settings.get_in_game_menu_fields()
-            total_items = len(menu_fields) + 1  # +1 for "Return to Menu"
             return_to_menu_index = len(menu_fields)
 
             item_font_size = int(surface_width / 30)

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -178,7 +178,15 @@ class GameModesScene(BaseScene):
     def on_enter(self) -> None:
         """Called when entering game modes scene."""
         self._selected_index = 0
-        self._confirmed_mode_index = 0  # default to first mode (Classic)
+
+        # restore previously confirmed mode based on stored selection
+        current_mode = get_selected_game_mode()
+        for i, mode in enumerate(self._game_modes):
+            if mode["type"] == current_mode:
+                self._confirmed_mode_index = i
+                break
+        else:
+            self._confirmed_mode_index = 0  # default to first mode (Classic)
 
     def get_selected_mode(self) -> GameModeType:
         """Get the currently selected game mode.

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -68,9 +68,9 @@ class GameModesScene(BaseScene):
             },
             {
                 "name": "More Fruits Mode",
-                "description": "Multiple fruit varieties (Coming Soon)",
+                "description": "Multiple fruit varieties with different effects",
                 "type": GameModeType.MORE_FRUITS,
-                "available": False,
+                "available": True,
             },
             {
                 "name": "Poisoned Apple Mode",
@@ -109,8 +109,10 @@ class GameModesScene(BaseScene):
                 elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
                     selected_mode = self._game_modes[self._selected_index]
                     if selected_mode["available"]:
-                        # start game with selected mode
+                        # save selected mode
                         self._selected_mode = selected_mode["type"]
+                        # store selection for gameplay scene to read
+                        self._store_game_mode_selection()
                         return "gameplay"
                 elif event.key == pygame.K_ESCAPE:
                     # return to main menu
@@ -174,3 +176,26 @@ class GameModesScene(BaseScene):
             Selected game mode type
         """
         return self._selected_mode
+
+    def _store_game_mode_selection(self) -> None:
+        """Store the selected game mode in a global settings variable.
+
+        This is a temporary solution until we have proper scene communication.
+        """
+        # store in global variable for gameplay scene to read
+        import src.game.scenes.game_modes as gm_module
+
+        gm_module._SELECTED_GAME_MODE = self._selected_mode
+
+
+# module-level variable for scene communication
+_SELECTED_GAME_MODE = GameModeType.CLASSIC
+
+
+def get_selected_game_mode() -> GameModeType:
+    """Get the currently selected game mode.
+
+    Returns:
+        Selected game mode type
+    """
+    return _SELECTED_GAME_MODE

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -74,9 +74,9 @@ class GameModesScene(BaseScene):
             },
             {
                 "name": "Poisoned Apple Mode",
-                "description": "Deadly poisoned apples appear (Coming Soon)",
+                "description": "Deadly dark purple apples that end the game instantly",
                 "type": GameModeType.POISONED_APPLE,
-                "available": False,
+                "available": True,
             },
         ]
 

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Game modes selection scene."""
+
+from __future__ import annotations
+
+import pygame
+from typing import Optional
+
+from src.game.scenes.base_scene import BaseScene
+from src.game.services.assets import GameAssets
+from src.game.settings import GameSettings
+from src.game.constants import ARENA_COLOR, MESSAGE_COLOR, SCORE_COLOR, GRID_COLOR
+from src.ecs.components.game_mode import GameModeType
+
+
+class GameModesScene(BaseScene):
+    """Game modes selection scene."""
+
+    def __init__(
+        self,
+        pygame_adapter,
+        renderer,
+        width: int,
+        height: int,
+        assets: GameAssets,
+        settings: GameSettings,
+    ):
+        """Initialize the game modes scene.
+
+        Args:
+            pygame_adapter: Pygame IO adapter
+            renderer: Renderer for drawing
+            width: Scene width
+            height: Scene height
+            assets: Game assets
+            settings: Game settings
+        """
+        super().__init__(pygame_adapter, renderer, width, height)
+        self._assets = assets
+        self._settings = settings
+        self._selected_index = 0
+
+        # define available game modes
+        self._game_modes = [
+            {
+                "name": "Classic Mode",
+                "description": "Traditional snake game with apples",
+                "type": GameModeType.CLASSIC,
+                "available": True,
+            },
+            {
+                "name": "More Fruits Mode",
+                "description": "Multiple fruit varieties (Coming Soon)",
+                "type": GameModeType.MORE_FRUITS,
+                "available": False,
+            },
+            {
+                "name": "Poisoned Apple Mode",
+                "description": "Deadly poisoned apples appear (Coming Soon)",
+                "type": GameModeType.POISONED_APPLE,
+                "available": False,
+            },
+        ]
+
+        self._selected_mode = GameModeType.CLASSIC
+
+    def update(self, dt_ms: float) -> Optional[str]:
+        """Update game modes selection logic.
+
+        Args:
+            dt_ms: Delta time in milliseconds
+
+        Returns:
+            Next scene name or None
+        """
+        # handle input
+        for event in self._pygame_adapter.get_events():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                exit()
+
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_UP, pygame.K_w):
+                    self._selected_index = (self._selected_index - 1) % len(
+                        self._game_modes
+                    )
+                elif event.key in (pygame.K_DOWN, pygame.K_s):
+                    self._selected_index = (self._selected_index + 1) % len(
+                        self._game_modes
+                    )
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    selected_mode = self._game_modes[self._selected_index]
+                    if selected_mode["available"]:
+                        # start game with selected mode
+                        self._selected_mode = selected_mode["type"]
+                        return "gameplay"
+                elif event.key == pygame.K_ESCAPE:
+                    # return to main menu
+                    return "menu"
+
+        return None
+
+    def render(self) -> None:
+        """Render the game modes selection menu."""
+        # clear screen
+        self._renderer.fill(ARENA_COLOR)
+
+        # draw title
+        title = self._assets.render_custom(
+            "Game Modes", MESSAGE_COLOR, int(self._width / 12)
+        )
+        title_rect = title.get_rect(center=(self._width / 2, self._height / 8))
+        self._renderer.blit(title, title_rect)
+
+        # draw game modes
+        start_y = self._height / 3
+        spacing = self._height * 0.15
+
+        for i, mode in enumerate(self._game_modes):
+            # determine color based on availability and selection
+            if i == self._selected_index:
+                color = SCORE_COLOR if mode["available"] else GRID_COLOR
+            else:
+                color = MESSAGE_COLOR if mode["available"] else GRID_COLOR
+
+            # render mode name
+            mode_text = self._assets.render_small(mode["name"], color)
+            mode_rect = mode_text.get_rect(
+                center=(self._width / 2, start_y + i * spacing)
+            )
+            self._renderer.blit(mode_text, mode_rect)
+
+            # render mode description (smaller text)
+            desc_text = self._assets.render_custom(
+                mode["description"], color, int(self._width / 50)
+            )
+            desc_rect = desc_text.get_rect(
+                center=(self._width / 2, start_y + i * spacing + self._height * 0.04)
+            )
+            self._renderer.blit(desc_text, desc_rect)
+
+        # draw hint footer
+        hint_text = "[W/S] navigate   [Enter] select   [Esc] back to menu"
+        hint = self._assets.render_custom(hint_text, GRID_COLOR, int(self._width / 50))
+        hint_rect = hint.get_rect(center=(self._width / 2, self._height * 0.92))
+        self._renderer.blit(hint, hint_rect)
+
+    def on_enter(self) -> None:
+        """Called when entering game modes scene."""
+        self._selected_index = 0
+
+    def get_selected_mode(self) -> GameModeType:
+        """Get the currently selected game mode.
+
+        Returns:
+            Selected game mode type
+        """
+        return self._selected_mode

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -194,8 +194,16 @@ class GameplayScene(BaseScene):
                 continue
             system.update(self._world)
 
-        # draw pause overlay on top of frozen game
-        if is_paused and self._ui_render_system:
+        # draw settings overlay if settings menu is open
+        if game_state and game_state.settings_menu_open and self._ui_render_system:
+            self._ui_render_system.draw_settings_overlay(
+                self._renderer.width,
+                self._renderer.height,
+                game_state.settings_selected_index,
+                self._config,
+            )
+        # draw pause overlay on top of frozen game (if not showing settings)
+        elif is_paused and self._ui_render_system:
             self._ui_render_system.draw_pause_overlay(
                 self._renderer.width, self._renderer.height
             )

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -42,6 +42,7 @@ from src.ecs.systems.board_render import BoardRenderSystem
 from src.ecs.systems.snake_render import SnakeRenderSystem
 from src.ecs.systems.entity_render import EntityRenderSystem
 from src.ecs.systems.ui_render import UIRenderSystem
+from src.ecs.systems.overlay_render import OverlayRenderSystem
 from src.ecs.systems.obstacle_generation import ObstacleGenerationSystem
 from src.ecs.systems.settings_apply import SettingsApplySystem
 
@@ -88,6 +89,7 @@ class GameplayScene(BaseScene):
         self._snake_render_system: Optional[SnakeRenderSystem] = None
         self._entity_render_system: Optional[EntityRenderSystem] = None
         self._ui_render_system: Optional[UIRenderSystem] = None
+        self._overlay_render_system: Optional[OverlayRenderSystem] = None
         self._game_initializer = GameInitializer(settings=settings)
         self._audio_service = AudioService(settings=settings)
         self._sfx_queue_service = SfxQueueService()
@@ -149,6 +151,9 @@ class GameplayScene(BaseScene):
             self._entity_render_system = EntityRenderSystem(self._renderer)
             self._snake_render_system = SnakeRenderSystem(self._renderer)
             self._ui_render_system = UIRenderSystem(self._renderer, self._settings)
+            self._overlay_render_system = OverlayRenderSystem(
+                self._renderer, self._settings, self._config
+            )
             self._systems.extend(
                 [
                     self._board_render_system,
@@ -195,16 +200,15 @@ class GameplayScene(BaseScene):
             system.update(self._world)
 
         # draw settings overlay if settings menu is open
-        if game_state and game_state.settings_menu_open and self._ui_render_system:
-            self._ui_render_system.draw_settings_overlay(
+        if game_state and game_state.settings_menu_open and self._overlay_render_system:
+            self._overlay_render_system.draw_settings_overlay(
                 self._renderer.width,
                 self._renderer.height,
                 game_state.settings_selected_index,
-                self._config,
             )
         # draw pause overlay on top of frozen game (if not showing settings)
-        elif is_paused and self._ui_render_system:
-            self._ui_render_system.draw_pause_overlay(
+        elif is_paused and self._overlay_render_system:
+            self._overlay_render_system.draw_pause_overlay(
                 self._renderer.width, self._renderer.height
             )
 

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -108,6 +108,7 @@ class GameplayScene(BaseScene):
         # game logic systems (indices 0-7, paused during pause)
         from src.ecs.systems.apple_spawn import AppleSpawnSystem
         from src.ecs.systems.fruit_spawn import FruitSpawnSystem
+        from src.ecs.systems.poisoned_apple_spawn import PoisonedAppleSpawnSystem
 
         # determine which spawn system to use based on game mode
         game_mode = self._get_game_mode()
@@ -117,6 +118,10 @@ class GameplayScene(BaseScene):
             spawn_system = FruitSpawnSystem(
                 1000
             )  # multi-fruit spawn with probabilities
+        elif game_mode == GameModeType.POISONED_APPLE:
+            spawn_system = PoisonedAppleSpawnSystem(
+                1000, poison_spawn_chance=0.01
+            )  # 1% chance per frame to spawn poisoned apple
         else:
             spawn_system = AppleSpawnSystem(1000)  # classic apple-only spawn
 

--- a/src/game/scenes/menu.py
+++ b/src/game/scenes/menu.py
@@ -47,6 +47,7 @@ from src.game.scenes.base_scene import BaseScene
 from src.game.services.assets import GameAssets
 from src.game.settings import GameSettings
 from src.game.constants import ARENA_COLOR, MESSAGE_COLOR, SCORE_COLOR, WINDOW_TITLE
+from src.ecs.components.game_mode import GameModeType
 
 
 class MenuScene(BaseScene):
@@ -129,6 +130,18 @@ class MenuScene(BaseScene):
         title_rect = title.get_rect(center=(self._width / 2, self._height / 4))
         self._renderer.blit(title, title_rect)
 
+        # Draw selected game mode under title (if not Classic)
+        selected_mode = self._get_selected_game_mode()
+        if selected_mode != GameModeType.CLASSIC:
+            mode_name = self._get_mode_display_name(selected_mode)
+            mode_text = self._assets.render_custom(
+                mode_name, (150, 150, 150), int(self._width / 35)
+            )
+            mode_rect = mode_text.get_rect(
+                center=(self._width / 2, self._height / 4 + self._height * 0.08)
+            )
+            self._renderer.blit(mode_text, mode_rect)
+
         # Draw menu items
         for i, item in enumerate(self._menu_items):
             color = SCORE_COLOR if i == self._selected_index else MESSAGE_COLOR
@@ -146,3 +159,32 @@ class MenuScene(BaseScene):
         # (it might have stopped if coming from game over)
         if self._settings.get("background_music"):
             GameAssets.play_background_music(loop=True)
+
+    def _get_selected_game_mode(self) -> GameModeType:
+        """Get the currently selected game mode.
+
+        Returns:
+            Currently selected GameModeType
+        """
+        try:
+            from src.game.scenes.game_modes import get_selected_game_mode
+
+            return get_selected_game_mode()
+        except Exception:
+            return GameModeType.CLASSIC
+
+    def _get_mode_display_name(self, mode: GameModeType) -> str:
+        """Get display name for game mode.
+
+        Args:
+            mode: GameModeType enum value
+
+        Returns:
+            Human-readable mode name
+        """
+        mode_names = {
+            GameModeType.CLASSIC: "Classic Mode",
+            GameModeType.MORE_FRUITS: "More Fruits Mode",
+            GameModeType.POISONED_APPLE: "Poisoned Apple Mode",
+        }
+        return mode_names.get(mode, "Classic Mode")

--- a/src/game/scenes/menu.py
+++ b/src/game/scenes/menu.py
@@ -75,7 +75,7 @@ class MenuScene(BaseScene):
         self._assets = assets
         self._settings = settings
         self._selected_index = 0
-        self._menu_items = ["Start Game", "Settings", "Quit"]
+        self._menu_items = ["Start Game", "Game Modes", "Settings", "Quit"]
 
     def update(self, dt_ms: float) -> Optional[str]:
         """Update menu logic.
@@ -104,6 +104,8 @@ class MenuScene(BaseScene):
                 elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
                     if self._menu_items[self._selected_index] == "Start Game":
                         return "gameplay"
+                    elif self._menu_items[self._selected_index] == "Game Modes":
+                        return "game_modes"
                     elif self._menu_items[self._selected_index] == "Settings":
                         return "settings"
                     elif self._menu_items[self._selected_index] == "Quit":

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -47,6 +47,7 @@ class GameSettings:
             "min": 10,
             "max": 60,
             "step": 1,
+            "requires_reset": True,
         },
         {
             "key": "initial_speed",
@@ -55,6 +56,7 @@ class GameSettings:
             "min": 1.0,
             "max": 40.0,
             "step": 0.5,
+            "requires_reset": True,
         },
         {
             "key": "max_speed",
@@ -63,12 +65,14 @@ class GameSettings:
             "min": 4.0,
             "max": 60.0,
             "step": 1.0,
+            "requires_reset": True,
         },
         {
             "key": "obstacle_difficulty",
             "label": "Obstacles",
             "type": "select",
             "options": ["None", "Easy", "Medium", "Hard", "Impossible"],
+            "requires_reset": True,
         },
         {
             "key": "number_of_apples",
@@ -77,19 +81,32 @@ class GameSettings:
             "min": 1,
             "max": 30,
             "step": 1,
+            "requires_reset": True,
         },
-        {"key": "background_music", "label": "Background Music", "type": "bool"},
-        {"key": "sound_effects", "label": "Sound Effects", "type": "bool"},
+        {
+            "key": "background_music",
+            "label": "Background Music",
+            "type": "bool",
+            "requires_reset": False,
+        },
+        {
+            "key": "sound_effects",
+            "label": "Sound Effects",
+            "type": "bool",
+            "requires_reset": False,
+        },
         {
             "key": "electric_walls",
             "label": "Electric walls",
             "type": "bool",
+            "requires_reset": True,
         },
         {
             "key": "snake_color_palette",
             "label": "Snake Color",
             "type": "select",
             "options": [palette["name"] for palette in SNAKE_COLOR_PALETTES],
+            "requires_reset": False,
         },
     ]
 
@@ -298,3 +315,17 @@ class GameSettings:
 
         random_palette = get_random_snake_colors()
         self.settings["snake_color_palette"] = random_palette["name"]
+
+    def get_in_game_menu_fields(self) -> list:
+        """Get menu fields that can be changed during gameplay.
+
+        Returns only settings that don't require a game reset.
+
+        Returns:
+            List of field definitions that can be adjusted mid-game
+        """
+        return [
+            field
+            for field in self.MENU_FIELDS
+            if not field.get("requires_reset", False)
+        ]


### PR DESCRIPTION
## Description
Adds a Game Modes menu with three playable modes: Classic, More Fruits, and Poisoned Apple. Players can select their preferred mode from the main menu before starting a game.

## Related Issue
Closes #91

## Changes Made

### Game Modes Menu
- Added "Game Modes" button to main menu
- Created GameModesScene for mode selection
- Selected mode displays under title in main menu
- Visual feedback with ► indicator and green highlight

### Three Game Modes Implemented

**Classic Mode** (Default)
- Traditional snake gameplay with regular apples

**More Fruits Mode**
- 🍎 Apple (Red): +1 segment, +10% speed, 65% spawn rate
- 🍇 Grape (Purple): +1 segment, -20% speed, 25% spawn rate
- 🍊 Orange: +2 segments, +10% speed, 10% spawn rate (rare!)
- Different fruits affect growth and speed dynamically

**Poisoned Apple Mode**
- Regular Apple (Red): Always present, safe to eat
- Poisoned Apple (Dark Purple): Instant game over, spawns randomly
- Adds risk/reward gameplay element

### Technical Implementation
- Created `GameMode` component for tracking selected mode
- Created `FruitSpawnSystem` with weighted probability spawning
- Created `PoisonedAppleSpawnSystem` with smart spawn logic
- Updated `CollisionSystem` to handle variable growth, speed modifiers, and poisoned apples
- Added prefabs for grape, orange, and poisoned apple entities
- Mode selection persists across menu navigation
- All systems follow ECS architecture (under 300 lines, pure data components)

## Screenshots
<img width="711" height="540" alt="Screenshot 2025-11-08 at 17 38 08" src="https://github.com/user-attachments/assets/befd7e91-1522-427a-b9da-139cb93b9908" />
<img width="762" height="710" alt="Screenshot 2025-11-08 at 17 38 34" src="https://github.com/user-attachments/assets/87a4f9cc-989b-421f-a941-b2387d8981dd" />
