### PR TITLE
[FEAT] create a hunger bar option

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -180,6 +180,7 @@ class ECSGameApp:
             initial_speed=float(self.settings.get("initial_speed")),
             head_color=None,  # will use default from palette
             tail_color=None,  # will use default from palette
+            enable_hunger=bool(self.settings.get("enable_hunger")),
         )
 
         # create apple at random valid position

--- a/src/ecs/components/hunger.py
+++ b/src/ecs/components/hunger.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Hunger component."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Hunger:
+    """Hunger/starvation timer for the snake.
+
+    The snake must eat apples before hunger reaches 0 or it dies.
+    Eating an apple resets the hunger timer to max_time.
+
+    Attributes:
+        current_time: Current hunger timer value in seconds (counts down)
+        max_time: Maximum hunger time before starvation death (default: 10.0 seconds)
+
+    Used by: Snake entity (singleton pattern for now)
+    """
+
+    current_time: float = field(default=10.0)
+    max_time: float = field(default=10.0)

--- a/src/ecs/entities/snake.py
+++ b/src/ecs/entities/snake.py
@@ -26,6 +26,7 @@ from src.ecs.components.position import Position
 from src.ecs.components.velocity import Velocity
 from src.ecs.components.snake_body import SnakeBody
 from src.ecs.components.interpolation import Interpolation
+from src.ecs.components.hunger import Hunger
 from src.ecs.components.renderable import Renderable
 
 
@@ -49,6 +50,7 @@ class Snake(Entity):
     body: SnakeBody
     interpolation: Interpolation
     renderable: Renderable
+    hunger: Hunger
 
     def get_type(self) -> EntityType:
         """Get the type of this entity.

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -27,7 +27,9 @@ from src.ecs.components.velocity import Velocity
 from src.ecs.components.snake_body import SnakeBody
 from src.ecs.components.interpolation import Interpolation
 from src.ecs.components.renderable import Renderable
+from src.ecs.components.hunger import Hunger
 from src.core.types.color import Color
+from src.game import constants
 
 
 def create_snake(
@@ -36,6 +38,7 @@ def create_snake(
     initial_speed: float = 4.0,
     head_color: Optional[tuple[int, int, int]] = None,
     tail_color: Optional[tuple[int, int, int]] = None,
+    enable_hunger: bool = False,
 ) -> int:
     """Create a snake entity with all required components.
 
@@ -71,6 +74,14 @@ def create_snake(
         position=Position(x=start_x, y=start_y, prev_x=start_x, prev_y=start_y),
         velocity=Velocity(dx=1, dy=0, speed=initial_speed),
         body=SnakeBody(segments=[], size=1, alive=True),
+        hunger=(
+            Hunger(
+                current_time=constants.HUNGER_MAX_TIME,
+                max_time=constants.HUNGER_MAX_TIME,
+            )
+            if enable_hunger
+            else Hunger(current_time=0.0, max_time=0.0)
+        ),
         interpolation=Interpolation(alpha=0.0, wrapped_axis="none"),
         renderable=Renderable(
             shape="square",

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -313,6 +313,27 @@ class CollisionSystem(BaseSystem):
                         new_speed = min(current_speed * 1.1, max_speed)
                         snake.velocity.speed = new_speed
 
+                    # reset hunger timer when apple is eaten (if enabled)
+                    if self._settings and bool(self._settings.get("enable_hunger")):
+                        hunger_entities = world.registry.query_by_component("hunger")
+                        if hunger_entities:
+                            he = list(hunger_entities.values())[0]
+                            if hasattr(he, "hunger"):
+                                # Recompute hunger max_time from current snake velocity
+                                snake_for_hunger = self._get_snake_entity(world)
+                                try:
+                                    if (
+                                        snake_for_hunger
+                                        and hasattr(snake_for_hunger, "velocity")
+                                        and snake_for_hunger.velocity.speed > 0
+                                    ):
+                                        he.hunger.max_time = 50.0 / float(
+                                            snake_for_hunger.velocity.speed
+                                        )
+                                except Exception:
+                                    pass
+                                # reset current time to (possibly updated) max
+                                he.hunger.current_time = he.hunger.max_time
                     # remove eaten apple
                     world.registry.remove(entity_id)
 

--- a/src/ecs/systems/hunger.py
+++ b/src/ecs/systems/hunger.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Hunger system for snake starvation mechanics.
+
+This system manages the hunger countdown timer and handles death by starvation.
+When hunger reaches 0, the snake dies and the game ends.
+"""
+
+from typing import Optional, Any
+
+from src.ecs.systems.base_system import BaseSystem
+from src.ecs.world import World
+from src.ecs.entities.entity import EntityType
+
+
+class HungerSystem(BaseSystem):
+    """System for managing snake hunger and starvation.
+
+    Reads: Hunger, SnakeBody
+    Writes: Hunger (current_time), GameState (death on starvation)
+    Queries: entities with Hunger component
+
+    Responsibilities:
+    - Decrement hunger counter each frame
+    - Detect starvation (hunger reaches 0)
+    - Handle starvation death (modify GameState, play sounds)
+    - Allow external reset of hunger (called on apple eaten)
+
+    Note: This system is responsible only for countdown and death detection.
+    Hunger reset is triggered externally (e.g., by CollisionSystem on apple eaten).
+    """
+
+    def __init__(self, audio_service: Optional[Any] = None):
+        """Initialize the HungerSystem.
+
+        Args:
+            audio_service: Optional audio service for playing death sounds
+        """
+        self._audio_service = audio_service
+
+    def update(self, world: World) -> None:
+        """Decrement hunger timer and check for starvation.
+
+        Called every frame. Updates hunger countdown and detects death by starvation.
+
+        Args:
+            world: ECS world
+        """
+        # Find entities with hunger component
+        hunger_entities = world.registry.query_by_component("hunger")
+
+        for entity_id, entity in hunger_entities.items():
+            if not hasattr(entity, "hunger"):
+                continue
+
+            hunger = entity.hunger
+
+            # If max_time is zero or negative, hunger is disabled for this entity
+            if not hunger.max_time or hunger.max_time <= 0:
+                continue
+
+            # Recalculate hunger max_time based on current snake velocity if possible
+            # Formula: hunger max time = 50 / current_velocity -> shortens the time as the snake gets fasters
+            snake = self._get_snake_entity(world)
+            try:
+                if snake and hasattr(snake, "velocity") and snake.velocity.speed > 0:
+                    hunger.max_time = 50.0 / float(snake.velocity.speed)
+            except Exception:
+                # keep existing hunger.max_time on error
+                pass
+
+            # Ensure current_time does not exceed the (possibly updated) max
+            if hunger.current_time > hunger.max_time:
+                hunger.current_time = hunger.max_time
+
+            # Decrement hunger by frame delta time (use world.dt_ms for accurate timing)
+            delta_time = world.dt_ms / 1000.0
+            hunger.current_time -= delta_time
+
+            # Clamp to 0
+            if hunger.current_time < 0:
+                hunger.current_time = 0
+
+            # Check for starvation
+            if hunger.current_time <= 0:
+                self._handle_starvation(world)
+
+    def _get_hunger_entity(self, world: World):
+        """Get the Hunger component from world.
+
+        Args:
+            world: ECS world
+
+        Returns:
+            Hunger component or None if not found
+        """
+        hunger_entities = world.registry.query_by_component("hunger")
+        if hunger_entities:
+            entity = next(iter(hunger_entities.values()))
+            if hasattr(entity, "hunger"):
+                return entity.hunger
+        return None
+
+    def _get_game_state(self, world: World):
+        """Get the GameState component from world.
+
+        Args:
+            world: ECS world
+
+        Returns:
+            GameState component or None if not found
+        """
+        game_state_entities = world.registry.query_by_component("game_state")
+        if game_state_entities:
+            entity = next(iter(game_state_entities.values()))
+            if hasattr(entity, "game_state"):
+                return entity.game_state
+        return None
+
+    def reset_hunger(self, world: World) -> None:
+        """Reset hunger timer to maximum.
+
+        Called when apple is eaten.
+
+        Args:
+            world: ECS world
+        """
+        hunger = self._get_hunger_entity(world)
+        if hunger:
+            hunger.current_time = hunger.max_time
+
+    def get_hunger_ratio(self, world: World) -> float:
+        """Get hunger as a ratio (0.0 to 1.0).
+
+        Used for rendering the hunger bar.
+
+        Args:
+            world: ECS world
+
+        Returns:
+            Hunger ratio (current_time / max_time), or 0.0 if no hunger entity
+        """
+        hunger = self._get_hunger_entity(world)
+        if hunger:
+            if hunger.max_time > 0:
+                return hunger.current_time / hunger.max_time
+            return 0.0
+        return 0.0
+
+    def get_hunger_time(self, world: World) -> float:
+        """Get current hunger time in seconds.
+
+        Args:
+            world: ECS world
+
+        Returns:
+            Current hunger time in seconds, or 0.0 if no hunger entity
+        """
+        hunger = self._get_hunger_entity(world)
+        if hunger:
+            return hunger.current_time
+        return 0.0
+
+    def _get_snake_entity(self, world: World):
+        """Get the snake entity from world.
+
+        Args:
+            world: ECS world
+
+        Returns:
+            Snake entity or None if not found
+        """
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for _, snake in snakes.items():
+            return snake
+        return None
+
+    def _handle_starvation(self, world: World) -> None:
+        """Handle snake death by starvation.
+
+        Modifies GameState component and plays death audio.
+
+        Args:
+            world: ECS world
+        """
+        # Kill the snake
+        snake = self._get_snake_entity(world)
+        if snake and hasattr(snake, "body"):
+            snake.body.alive = False
+
+        # Play death sound and music
+        if self._audio_service:
+            self._audio_service.play_sound("assets/sound/gameover.wav")
+            self._audio_service.play_music("assets/sound/death_song.mp3")
+
+        # Update game state
+        game_state = self._get_game_state(world)
+        if game_state:
+            game_state.game_over = True
+            game_state.death_reason = "starvation"
+            game_state.next_scene = "game_over"
+
+        print("☠️  DEATH CAUSE: Starvation")

--- a/src/game/constants.py
+++ b/src/game/constants.py
@@ -16,9 +16,12 @@ ARENA_COLOR = "#202020"  # Color of the ground.
 GRID_COLOR = "#3c3c3b"  # Color of the grid lines.
 SCORE_COLOR = "#ffffff"  # Color of the scoreboard.
 MESSAGE_COLOR = "#808080"  # Color of the game-over message.
+HUNGER_COLOR = "#ffaa00"  # Color of the hunger bar (orange/yellow).
 
 WINDOW_TITLE = "KobraPy"  # Window title.
 CLOCK_TICKS = 4  # How fast the snake moves.
+HUNGER_MAX_TIME = 10.0  # Maximum hunger time in seconds before starvation death.
+HUNGER_MIN_TIME = 3.0  # Minimum hunger time at maximum velocity
 
 # Difficulty percentages for obstacle count
 DIFFICULTY_PERCENTAGES = {

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -45,6 +45,7 @@ from src.ecs.systems.ui_render import UIRenderSystem
 from src.ecs.systems.overlay_render import OverlayRenderSystem
 from src.ecs.systems.obstacle_generation import ObstacleGenerationSystem
 from src.ecs.systems.settings_apply import SettingsApplySystem
+from src.ecs.systems.hunger import HungerSystem
 
 
 class GameplayScene(BaseScene):
@@ -124,9 +125,15 @@ class GameplayScene(BaseScene):
                     1000, (255, 0, 0), None
                 ),  # 4: create new entities at valid positions
                 ScoringSystem(),  # 5: track score and high score
+                # conditionally enable HungerSystem based on game settings
+                *(
+                    [HungerSystem(self._audio_service)]
+                    if self._settings and bool(self._settings.get("enable_hunger"))
+                    else []
+                ),
                 ObstacleGenerationSystem(
                     100, 8, 2, None
-                ),  # 6: generate obstacles with connectivity guarantees
+                ),  # conditional: generate obstacles with connectivity guarantees
                 SettingsApplySystem(
                     self._settings, self._config, self._assets
                 ),  # 7: apply runtime settings changes (colors, difficulty, etc)

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -181,6 +181,7 @@ class GameInitializer:
             initial_speed=float(self._settings.get("initial_speed")),
             head_color=head_color,
             tail_color=tail_color,
+            enable_hunger=bool(self._settings.get("enable_hunger")),
         )
 
     def _create_apple_config(self, world: World) -> None:

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -36,6 +36,7 @@ class GameSettings:
         "sound_effects": True,  # Controls all sound effects (eat, death, etc.)
         "electric_walls": True,
         "snake_color_palette": "Classic Green",  # New setting
+        "enable_hunger": False,
     }
 
     # Declarative menu field definitions
@@ -94,6 +95,12 @@ class GameSettings:
             "label": "Sound Effects",
             "type": "bool",
             "requires_reset": False,
+        },
+        {
+            "key": "enable_hunger",
+            "label": "Hunger",
+            "type": "bool",
+            "requires_reset": True,
         },
         {
             "key": "electric_walls",


### PR DESCRIPTION
## Description
Adds an option that enables a "hunger bar". This new bar counts down until the snake eats a new apple (then it resets) or it reaches 0 (then the snake dies).

<img height="300" alt="option in settings" src="https://github.com/user-attachments/assets/faed65c1-1306-4ca3-ac70-f756ec2540d1" /> 
<img height="300" alt="image showing the bar" src="https://github.com/user-attachments/assets/c7de8bdd-de56-4811-8a0b-5bae371d7d9b" />

The maximum time is calculated by 50 / current_speed, so when the velocity increases, the time gets shorter. 

## Related Issue
Closes #299 

## Testing
- When the option is disabled, everything works normally
- When the option is enabled, the hunger bar appears
- The maximum time seams to be calculated right
- When the snake eats the apple, the time resets
- When the time reaches 0, the user loses

## Observations
- I used a lot of GenAI, so maybe there is a clearer way than that to do it
- The formula for the maximum time was achieved by testing some numbers until I get a challenging but possible time to beat, giving the current speed. Maybe there is a more clever way to calculate it