### PR TITLE
feat(ecs): add @skip_when_paused decorator for pausable systems (#316)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -115,6 +115,42 @@ wish.
 By submitting your contribution, you agree it will be available under the same
 license as Naja (GNU GPL v3 or later).
 
+### Development Notes: Decorators
+
+The file `src/ecs/systems/decorators.py` was added to provide a simple way to define class-level decorators for ECS systems.
+At the moment, it includes a single decorator: `@skip_when_paused`.
+
+#### `@skip_when_paused`
+
+This decorator marks a system to be skipped when the game is paused.
+It works by setting a class attribute `skip_when_paused = True`, which is later checked in the main update loop inside `gameplay.py`.
+
+#### How to use
+
+To use it, apply the decorator above the system class definition:
+
+```python
+from src.ecs.systems.decorators import skip_when_paused # noqa
+
+@skip_when_paused
+class ExampleClass(BaseSystem): # noqa
+    # System logic here
+    pass # noqa
+```
+Any new gameplay system that should stop updating while the game is paused can include this decorator.
+It helps keep the pause logic consistent across all systems and reduces manual configuration.
+
+If a new system is added to the main update loop and should also be paused, make sure to apply this decorator.
+Likewise, removing it from an existing system means that the system will continue running even while the game is paused.
+#### Updating Tests
+
+Whenever you add, remove, or modify systems that use the `@skip_when_paused` decorator,
+make sure to also update the test `test_skip_when_paused_flags_are_correct` in
+`tests/test_gameplay_scene.py`.
+
+This test validates that all systems correctly define their `skip_when_paused` attribute,
+so any new or removed system should be reflected in the corresponding test lists.
+
 Branch Naming
 ------------------------------
 

--- a/docs/adr/0001-choose-ecs.md
+++ b/docs/adr/0001-choose-ecs.md
@@ -31,7 +31,7 @@ This pattern separates data from behavior, making each piece small, focused, and
 
 **Negative:**
 - ❌ More files/abstractions than traditional OOP
-- ❌ Learning curve for contributors 
+- ❌ Learning curve for contributors
 
 **Mitigations:**
 - Comprehensive documentation in `docs/architecture.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Naja ECS Architecture
 
-> **Version:** 1.0 
+> **Version:** 1.0
 > **Last Updated:** October 2025
 > **Status:** Fully Implemented
 
@@ -76,11 +76,11 @@ class Position:
 ```python
 class MovementSystem(BaseSystem):
     """Moves entities based on velocity."""
-    
+
     def update(self, world):
         # Query entities with position + velocity
         entities = world.registry.query_by_component("position", "velocity")
-        
+
         for entity in entities.values():
             # Update position based on velocity
             entity.position.prev_x = entity.position.x
@@ -181,10 +181,10 @@ Systems in `src/ecs/systems/` process entities:
 ```python
 class InputSystem(BaseSystem):
     """Converts input into component changes."""
-    
+
     # Reads: pygame events
     # Writes: Velocity, GameState
-    
+
     # Example: right arrow
     if key == K_RIGHT and velocity.dx != -1:
         velocity.dx = 1
@@ -395,7 +395,7 @@ class AppleConfig:
 
 ```python
 # src/ecs/prefabs/apple.py
-def create_apple(world: World, x: int, y: int, grid_size: int, 
+def create_apple(world: World, x: int, y: int, grid_size: int,
                  color=None, points=10, growth=1) -> int:
     """Creates apple at position (x, y) with configured components."""
     apple = Apple(
@@ -424,17 +424,17 @@ class AppleSpawnSystem(BaseSystem):
     def update(self, world: World) -> None:
         # 1. How many do we want?
         desired_count = self._get_desired_apple_count(world)
-        
+
         # 2. How many do we have?
         current_apples = world.registry.query_by_type(EntityType.APPLE)
         current_count = len(current_apples)
-        
+
         # 3. Spawn difference
         for _ in range(desired_count - current_count):
             position = self._find_valid_position(world)
             if position:
                 create_apple(world, x=position[0], y=position[1], ...)
-    
+
     def _find_valid_position(self, world):
         """Finds position that doesn't collide with anything."""
         occupied = self._get_occupied_positions(world)
@@ -488,10 +488,10 @@ def test_spawn_maintains_apple_count():
     # Setup: want 3 apples
     config = Entity(apple_config=AppleConfig(desired_count=3))
     world.registry.add(config)
-    
+
     # Execute system
     system.update(world)
-    
+
     # Verify: has 3 apples?
     assert len(world.registry.query_by_type(EntityType.APPLE)) == 3
 
@@ -618,16 +618,16 @@ snake.velocity.dx = 1
 ```python
 class CollisionSystem(BaseSystem):
     """Detects snake vs apple/obstacle/wall collisions."""
-    
+
     def update(self, world):
         # Get snake
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         if not snakes:
             return
-        
+
         snake_id, snake = next(iter(snakes.items()))
         head_pos = (snake.position.x, snake.position.y)
-        
+
         # Check collision with apples
         apples = world.registry.query_by_type(EntityType.APPLE)
         for apple_id, apple in apples.items():
@@ -636,7 +636,7 @@ class CollisionSystem(BaseSystem):
                 # Collision! Grow snake and remove apple
                 snake.body.size += 1
                 world.registry.remove(apple_id)
-                
+
                 # Update score
                 score_entities = world.registry.query_by_component("score")
                 if score_entities:
@@ -655,23 +655,23 @@ def test_movement_system_moves_entity():
     # Setup
     board = Board(width=20, height=20, cell_size=20)
     world = World(board)
-    
+
     # Create test entity
     entity = Entity(
         position=Position(x=10, y=10),
         velocity=Velocity(dx=1, dy=0, speed=10.0)
     )
     entity_id = world.registry.add(entity)
-    
+
     # Create system
     system = MovementSystem()
-    
+
     # Simulate enough time to move
     world.dt_ms = 100  # 100ms
-    
+
     # Execute
     system.update(world)
-    
+
     # Verify
     entity = world.registry.get(entity_id)
     assert entity.position.x == 11
@@ -686,30 +686,30 @@ def test_snake_eats_apple():
     # Setup
     board = Board(width=20, height=20, cell_size=20)
     world = World(board)
-    
+
     # Create snake and apple at same position
     snake_id = create_snake(world, grid_size=20)
     snake = world.registry.get(snake_id)
     snake.position.x = 10
     snake.position.y = 10
-    
+
     apple_id = create_apple(world, grid_size=20)
     apple = world.registry.get(apple_id)
     apple.position.x = 10
     apple.position.y = 10
-    
+
     # Create score
     score_entity = Entity(score=Score(current=0))
     world.registry.add(score_entity)
-    
+
     # Execute collision system
     collision_system = CollisionSystem(settings=None, audio_service=None)
     collision_system.update(world)
-    
+
     # Verify
     assert snake.body.size == 2  # grew
     assert world.registry.get(apple_id) is None  # apple removed
-    
+
     score_entities = world.registry.query_by_component("score")
     score_entity = next(iter(score_entities.values()))
     assert score_entity.score.current == 10
@@ -751,4 +751,3 @@ pytest tests/ecs/test_movement_system.py  # specific test
 - `docs/CONTRIBUTING.md` - contribution guide
 - `docs/manual.md` - user manual
 - `.cursor/rules/` - detailed ECS rules
-

--- a/src/ecs/systems/apple_spawn.py
+++ b/src/ecs/systems/apple_spawn.py
@@ -29,11 +29,13 @@ import random
 from typing import Optional
 
 from src.ecs.systems.base_system import BaseSystem
+from src.ecs.systems.system_decorators import skip_when_paused
 from src.ecs.world import World
 from src.ecs.entities.entity import EntityType
 from src.ecs.prefabs.apple import create_apple
 
 
+@skip_when_paused
 class AppleSpawnSystem(BaseSystem):
     """System for maintaining the correct number of apples in the game.
 

--- a/src/ecs/systems/base_system.py
+++ b/src/ecs/systems/base_system.py
@@ -28,6 +28,8 @@ class BaseSystem(ABC):
     other systems must inherit from and implement in a concrete way.
     """
 
+    skip_when_paused = False
+
     @abstractmethod
     def update(self, world: World):
         """

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -31,9 +31,11 @@ Follows proper ECS architecture by querying world directly.
 from typing import Optional, Any
 
 from src.ecs.systems.base_system import BaseSystem
+from src.ecs.systems.system_decorators import skip_when_paused
 from src.ecs.world import World
 
 
+@skip_when_paused
 class CollisionSystem(BaseSystem):
     """System for detecting all types of collisions.
 

--- a/src/ecs/systems/movement.py
+++ b/src/ecs/systems/movement.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from typing import Optional, Callable
 
 from src.ecs.systems.base_system import BaseSystem
+from src.ecs.systems.system_decorators import skip_when_paused
 from src.ecs.world import World
 from src.ecs.entities.entity import EntityType
 from src.ecs.components.position import Position
@@ -31,6 +32,7 @@ from src.ecs.components.velocity import Velocity
 from src.ecs.components.snake_body import SnakeBody
 
 
+@skip_when_paused
 class MovementSystem(BaseSystem):
     """Update entity positions based on velocity and grid rules.
 

--- a/src/ecs/systems/obstacle_generation.py
+++ b/src/ecs/systems/obstacle_generation.py
@@ -32,6 +32,7 @@ import random
 from typing import Optional
 
 from src.ecs.systems.base_system import BaseSystem
+from src.ecs.systems.system_decorators import skip_when_paused
 from src.ecs.world import World
 from src.ecs.entities.obstacle_field import Obstacle as ObstacleEntity
 from src.ecs.components.position import Position
@@ -43,6 +44,7 @@ from src.game import constants
 GRID_DIRECTIONS = [(0, 1), (0, -1), (1, 0), (-1, 0)]
 
 
+@skip_when_paused
 class ObstacleGenerationSystem(BaseSystem):
     """System for generating obstacles with connectivity and trap guarantees.
 

--- a/src/ecs/systems/scoring.py
+++ b/src/ecs/systems/scoring.py
@@ -27,9 +27,11 @@ across game resets and settings changes.
 from __future__ import annotations
 
 from src.ecs.systems.base_system import BaseSystem
+from src.ecs.systems.system_decorators import skip_when_paused
 from src.ecs.world import World
 
 
+@skip_when_paused
 class ScoringSystem(BaseSystem):
     """System for managing score and high score.
 

--- a/src/ecs/systems/settings_apply.py
+++ b/src/ecs/systems/settings_apply.py
@@ -26,10 +26,12 @@ and entities in real-time during gameplay.
 from typing import Any, Optional
 import pygame
 from src.ecs.systems.base_system import BaseSystem
+from src.ecs.systems.system_decorators import skip_when_paused
 from src.ecs.world import World
 from src.ecs.entities.entity import EntityType
 
 
+@skip_when_paused
 class SettingsApplySystem(BaseSystem):
     """System that applies settings changes to the game world.
 

--- a/src/ecs/systems/spawn.py
+++ b/src/ecs/systems/spawn.py
@@ -29,11 +29,13 @@ import random
 from typing import Optional
 
 from src.ecs.systems.base_system import BaseSystem
+from src.ecs.systems.system_decorators import skip_when_paused
 from src.ecs.world import World
 from src.ecs.entities.entity import EntityType
 from src.ecs.prefabs.apple import create_apple
 
 
+@skip_when_paused
 class SpawnSystem(BaseSystem):
     """System for spawning new entities at valid positions.
 

--- a/src/ecs/systems/system_decorators.py
+++ b/src/ecs/systems/system_decorators.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Reusable decorators for ECS system classes.
+
+This module defines class-level decorators that modify or extend
+the behavior of ECS systems in a consistent and readable way.
+They are used to express runtime behavior declaratively, without
+requiring manual configuration in scene logic.
+"""
+
+
+def skip_when_paused(cls):
+    """Decorator that marks a system to be skipped when the game is paused.
+
+    Sets a class attribute `skip_when_paused = True` so that
+    the system can be conditionally skipped in the scene update loop.
+
+    Args:
+        cls: The system class being decorated.
+
+    Returns:
+        The same class with the `skip_when_paused` attribute set.
+    """
+    cls.skip_when_paused = True
+    return cls

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -189,13 +189,9 @@ class GameplayScene(BaseScene):
         game_state = self._get_game_state()
         is_paused = game_state.paused if game_state else False
 
-        # pause game logic systems (1-7) but keep input (0) and rendering (8+) running
-        GAME_LOGIC_START = 1
-        GAME_LOGIC_END = 7
-
-        for i, system in enumerate(self._systems):
-            # skip game logic when paused (movement, collision, spawning, etc.)
-            if is_paused and GAME_LOGIC_START <= i <= GAME_LOGIC_END:
+        for system in self._systems:
+            # skip systems marked with skip_when_paused when game is paused
+            if is_paused and getattr(system, "skip_when_paused", False):
                 continue
             system.update(self._world)
 

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -105,7 +105,6 @@ class GameplayScene(BaseScene):
 
         self._systems.clear()
 
-        # game logic systems (indices 0-7, paused during pause)
         from src.ecs.systems.apple_spawn import AppleSpawnSystem
 
         self._systems.extend(
@@ -133,7 +132,6 @@ class GameplayScene(BaseScene):
             ]
         )
 
-        # rendering and audio systems (indices 8+, always run even when paused)
         self._systems.extend(
             [
                 InterpolationSystem(

--- a/tests/game/test_gameplay_scene.py
+++ b/tests/game/test_gameplay_scene.py
@@ -210,6 +210,51 @@ class TestGameplayScene:
         # should still work, just without render system
         scene.update(16.0)
 
+    def test_skip_when_paused_flags_are_correct(self):
+        """Verify that each system correctly defines whether it should pause or continue when the game is paused."""
+        from src.ecs.systems import (
+            input,
+            movement,
+            collision,
+            apple_spawn,
+            spawn,
+            scoring,
+            obstacle_generation,
+            settings_apply,
+            interpolation,
+            audio,
+        )
+
+        # Systems that SHOULD be skipped when the game is paused
+        expected_skipped = [
+            movement.MovementSystem,
+            collision.CollisionSystem,
+            apple_spawn.AppleSpawnSystem,
+            spawn.SpawnSystem,
+            scoring.ScoringSystem,
+            obstacle_generation.ObstacleGenerationSystem,
+            settings_apply.SettingsApplySystem,
+        ]
+
+        # Systems that SHOULD NOT be skipped
+        expected_not_skipped = [
+            input.InputSystem,
+            interpolation.InterpolationSystem,
+            audio.AudioSystem,
+        ]
+
+        # Check that all paused systems are correctly marked
+        for system_cls in expected_skipped:
+            assert getattr(
+                system_cls, "skip_when_paused", False
+            ), "System should have skip_when_paused=True"
+
+        # Check that non-paused systems remain active
+        for system_cls in expected_not_skipped:
+            assert not getattr(
+                system_cls, "skip_when_paused", False
+            ), "System should NOT have skip_when_paused=True"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
### Summary
Implements a class decorator `@skip_when_paused` that marks systems to be skipped when the game is paused, replacing the hardcoded index range in `GameplayScene.update()`.

### Changes
- Added new file `src/ecs/systems/decorators.py`.
- Updated logic systems (Movement, Collision, AppleSpawn, Spawn, Scoring, ObstacleGeneration, SettingsApply) to use `@skip_when_paused`.
- Updated `GameplayScene.update()` to check the attribute instead of fixed index ranges.
- Added unit test `test_skip_when_paused_flags_are_correct`.
- Updated `CONTRIBUTING.md` to include decorator usage guidelines.

### Motivation
Makes the pause mechanism explicit per system and easier to maintain when adding or removing systems.

### Related Issue
Closes #316