### PR TITLE
Feat/321/obstacle generation clustering

### DIFF
--- a/src/game/constants.py
+++ b/src/game/constants.py
@@ -29,6 +29,15 @@ DIFFICULTY_PERCENTAGES = {
     "Impossible": 0.15,
 }
 
+# Clustering "jumping" probability for obstacle generation
+DIFFICULTY_CLUSTERING_PERCENTAGES = {
+    "None": 0.0,
+    "Easy": 0.3,
+    "Medium": 0.4,
+    "Hard": 0.5,
+    "Impossible": 0.6,
+}
+
 # Color palettes for snake customization
 SNAKE_COLOR_PALETTES = [
     # Classic Green


### PR DESCRIPTION
Closes #321

The first image is the new version with clustering, the second is the old with just random noise. This was done in the "medium" difficulty with a lower obstacle count and lower chances of clustering. The clustering probability can be adjusted by changing constans in the src/game/constants.py file under `DIFFICULTY_CLUSTERING_PERCENTAGES`

<img width="947" height="976" alt="new" src="https://github.com/user-attachments/assets/e1a74864-0fa0-41fb-a107-85103bb28ddd" />
<img width="950" height="979" alt="old" src="https://github.com/user-attachments/assets/5827701e-f42a-42f8-8fd0-c02084903430" />
