### PR TITLE
[FEAT] Settings Persistence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 license = { text = "GPL-3.0-or-later" }
 requires-python = ">=3.12"
 dependencies = [
+    "platformdirs>=4.5.0",
     "pygame>=2.6.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,7 @@ name = "naja"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "platformdirs" },
     { name = "pygame" },
 ]
 
@@ -119,7 +120,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pygame", specifier = ">=2.6.1" }]
+requires-dist = [
+    { name = "platformdirs", specifier = ">=4.5.0" },
+    { name = "pygame", specifier = ">=2.6.1" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Settings Persistence
This Pull Request makes settings persisted between sessions.
Solves #334

It saves all settings in a json in the user data directory, which varies depending on the operating system. A new dependency is needed to find this directory, the platformdirs package.

The save method is called by a decorator, which wraps the step method. As the step method has multiple return lines, wrapping it with a decorator reduces code repetition.