### PR TITLE
feat(packaging): set proper entrypoint and __main__.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dev:
 
 # Run the game
 run:
-	uv run python kobra.py
+	uv run naja
 
 # Format code
 format:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Quick Start
 1. **Run the game** (dependencies are installed automatically):
    ```bash
    make run
-   # Or directly: uv run python kobra.py
+   # Or directly: uv run naja
    ```
 
 ### For Contributors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 Homepage = "https://github.com/fossguild/naja"
 Repository = "https://github.com/fossguild/naja"
 
+[project.scripts]
+naja = "core:main"
+
 [dependency-groups]
 dev = [
     "pre-commit>=3.0.0",
@@ -20,3 +23,9 @@ dev = [
     "ruff>=0.6.0",
     "pytest>=8.0.0",
 ]
+
+[tool.uv]
+package = true
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -18,3 +18,12 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Core engine module."""
+
+from core.app import ECSGameApp
+
+
+def main():
+    """Main game entry point."""
+    app = ECSGameApp()
+    app.initialize()
+    app.run()

--- a/src/core/__main__.py
+++ b/src/core/__main__.py
@@ -22,14 +22,7 @@
 Thin bootstrap layer that initializes and runs the ECS-based game application.
 """
 
-from src.core.app import ECSGameApp
-
-
-def main():
-    """Main game entry point."""
-    app = ECSGameApp()
-    app.initialize()
-    app.run()
+from core import main
 
 
 if __name__ == "__main__":

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -25,23 +25,23 @@ depending on old_code.
 
 import sys
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.prefabs.snake import create_snake
-from src.ecs.prefabs.apple import create_apple
-from src.ecs.prefabs.obstacle_field import create_obstacles
-from src.game.scenes.scene_manager import SceneManager
-from src.game.scenes.menu import MenuScene
-from src.game.scenes.gameplay import GameplayScene
-from src.game.scenes.game_over import GameOverScene
-from src.game.scenes.settings import SettingsScene
-from src.core.io.pygame_adapter import PygameIOAdapter
-from src.core.clock import GameClock
-from src.game.config import GameConfig
-from src.game.settings import GameSettings
-from src.game.services.assets import GameAssets
-from src.game.constants import WINDOW_TITLE
-from src.core.rendering.pygame_surface_renderer import PygameSurfaceRenderer
+from ecs.world import World
+from ecs.board import Board
+from ecs.prefabs.snake import create_snake
+from ecs.prefabs.apple import create_apple
+from ecs.prefabs.obstacle_field import create_obstacles
+from game.scenes.scene_manager import SceneManager
+from game.scenes.menu import MenuScene
+from game.scenes.gameplay import GameplayScene
+from game.scenes.game_over import GameOverScene
+from game.scenes.settings import SettingsScene
+from core.io.pygame_adapter import PygameIOAdapter
+from core.clock import GameClock
+from game.config import GameConfig
+from game.settings import GameSettings
+from game.services.assets import GameAssets
+from game.constants import WINDOW_TITLE
+from core.rendering.pygame_surface_renderer import PygameSurfaceRenderer
 
 
 class ECSGameApp:

--- a/src/core/rendering/__init__.py
+++ b/src/core/rendering/__init__.py
@@ -19,6 +19,6 @@
 
 """Rendering utilities module."""
 
-from src.core.rendering.pygame_surface_renderer import PygameSurfaceRenderer
+from core.rendering.pygame_surface_renderer import PygameSurfaceRenderer
 
 __all__ = ["PygameSurfaceRenderer"]

--- a/src/core/types/__init__.py
+++ b/src/core/types/__init__.py
@@ -19,6 +19,6 @@
 
 """Core types module."""
 
-from src.core.types.color import Color
+from core.types.color import Color
 
 __all__ = ["Color"]

--- a/src/ecs/__init__.py
+++ b/src/ecs/__init__.py
@@ -19,10 +19,10 @@
 
 """ECS framework module."""
 
-from src.ecs.world import World
-from src.ecs.entity_registry import EntityRegistry
-from src.ecs.entities.entity import Entity, EntityType
-from src.ecs.board import Board, Tile, BoardOutOfBoundsError
+from ecs.world import World
+from ecs.entity_registry import EntityRegistry
+from ecs.entities.entity import Entity, EntityType
+from ecs.board import Board, Tile, BoardOutOfBoundsError
 
 
 __all__ = [

--- a/src/ecs/components/__init__.py
+++ b/src/ecs/components/__init__.py
@@ -19,18 +19,18 @@
 
 """Components module."""
 
-from src.ecs.components.position import Position
-from src.ecs.components.velocity import Velocity
-from src.ecs.components.snake_body import SnakeBody
-from src.ecs.components.edible import Edible
-from src.ecs.components.obstacle import ObstacleTag, Obstacle
-from src.ecs.components.interpolation import Interpolation
-from src.ecs.components.renderable import Renderable
-from src.ecs.components.grid import Grid
-from src.ecs.components.apple_config import AppleConfig
-from src.ecs.components.color_scheme import ColorScheme
-from src.ecs.components.game_state import GameState
-from src.ecs.components.score import Score
+from ecs.components.position import Position
+from ecs.components.velocity import Velocity
+from ecs.components.snake_body import SnakeBody
+from ecs.components.edible import Edible
+from ecs.components.obstacle import ObstacleTag, Obstacle
+from ecs.components.interpolation import Interpolation
+from ecs.components.renderable import Renderable
+from ecs.components.grid import Grid
+from ecs.components.apple_config import AppleConfig
+from ecs.components.color_scheme import ColorScheme
+from ecs.components.game_state import GameState
+from ecs.components.score import Score
 
 __all__ = [
     "Position",

--- a/src/ecs/components/color_scheme.py
+++ b/src/ecs/components/color_scheme.py
@@ -20,8 +20,8 @@
 """Color scheme component for global game colors."""
 
 from dataclasses import dataclass, field
-from src.core.types.color import Color
-from src.game.constants import (
+from core.types.color import Color
+from game.constants import (
     ARENA_COLOR,
     GRID_COLOR,
     HEAD_COLOR,
@@ -39,7 +39,7 @@ class ColorScheme:
     Rendering systems can query this component to get consistent
     colors across the game without hard-coding values.
 
-    Default colors are imported from src.game.constants to maintain
+    Default colors are imported from game.constants to maintain
     consistency across the codebase and avoid duplication.
 
     Attributes:

--- a/src/ecs/components/renderable.py
+++ b/src/ecs/components/renderable.py
@@ -22,7 +22,7 @@
 from dataclasses import dataclass
 from typing import Literal, Optional
 
-from src.core.types.color import Color
+from core.types.color import Color
 
 
 @dataclass

--- a/src/ecs/components/snake_body.py
+++ b/src/ecs/components/snake_body.py
@@ -21,7 +21,7 @@
 
 from dataclasses import dataclass, field
 
-from src.ecs.components.position import Position
+from ecs.components.position import Position
 
 
 @dataclass

--- a/src/ecs/entities/__init__.py
+++ b/src/ecs/entities/__init__.py
@@ -19,9 +19,9 @@
 
 """Entities module."""
 
-from src.ecs.entities.entity import Entity, EntityType
-from src.ecs.entities.snake import Snake
-from src.ecs.entities.apple import Apple
-from src.ecs.entities.obstacle_field import Obstacle
+from ecs.entities.entity import Entity, EntityType
+from ecs.entities.snake import Snake
+from ecs.entities.apple import Apple
+from ecs.entities.obstacle_field import Obstacle
 
 __all__ = ["Entity", "EntityType", "Snake", "Apple", "Obstacle"]

--- a/src/ecs/entities/apple.py
+++ b/src/ecs/entities/apple.py
@@ -21,10 +21,10 @@
 
 from dataclasses import dataclass
 
-from src.ecs.entities.entity import Entity, EntityType
-from src.ecs.components.position import Position
-from src.ecs.components.edible import Edible
-from src.ecs.components.renderable import Renderable
+from ecs.entities.entity import Entity, EntityType
+from ecs.components.position import Position
+from ecs.components.edible import Edible
+from ecs.components.renderable import Renderable
 
 
 @dataclass

--- a/src/ecs/entities/obstacle_field.py
+++ b/src/ecs/entities/obstacle_field.py
@@ -22,10 +22,10 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from src.ecs.entities.entity import Entity, EntityType
-from src.ecs.components.position import Position
-from src.ecs.components.obstacle import ObstacleTag
-from src.ecs.components.renderable import Renderable
+from ecs.entities.entity import Entity, EntityType
+from ecs.components.position import Position
+from ecs.components.obstacle import ObstacleTag
+from ecs.components.renderable import Renderable
 
 
 @dataclass

--- a/src/ecs/entities/snake.py
+++ b/src/ecs/entities/snake.py
@@ -21,12 +21,12 @@
 
 from dataclasses import dataclass
 
-from src.ecs.entities.entity import Entity, EntityType
-from src.ecs.components.position import Position
-from src.ecs.components.velocity import Velocity
-from src.ecs.components.snake_body import SnakeBody
-from src.ecs.components.interpolation import Interpolation
-from src.ecs.components.renderable import Renderable
+from ecs.entities.entity import Entity, EntityType
+from ecs.components.position import Position
+from ecs.components.velocity import Velocity
+from ecs.components.snake_body import SnakeBody
+from ecs.components.interpolation import Interpolation
+from ecs.components.renderable import Renderable
 
 
 @dataclass

--- a/src/ecs/entity_registry.py
+++ b/src/ecs/entity_registry.py
@@ -19,7 +19,7 @@
 
 """Entity registry for managing game entities and querying them"""
 
-from src.ecs.entities.entity import Entity, EntityType
+from ecs.entities.entity import Entity, EntityType
 
 __all__ = ["EntityRegistry"]
 

--- a/src/ecs/prefabs/__init__.py
+++ b/src/ecs/prefabs/__init__.py
@@ -18,8 +18,8 @@
 
 """Prefab factory functions for creating game entities."""
 
-from src.ecs.prefabs.snake import create_snake
-from src.ecs.prefabs.apple import create_apple
-from src.ecs.prefabs.obstacle_field import create_obstacles
+from ecs.prefabs.snake import create_snake
+from ecs.prefabs.apple import create_apple
+from ecs.prefabs.obstacle_field import create_obstacles
 
 __all__ = ["create_snake", "create_apple", "create_obstacles"]

--- a/src/ecs/prefabs/apple.py
+++ b/src/ecs/prefabs/apple.py
@@ -21,12 +21,12 @@
 
 from typing import Optional
 
-from src.ecs.world import World
-from src.ecs.entities.apple import Apple
-from src.ecs.components.position import Position
-from src.ecs.components.edible import Edible
-from src.ecs.components.renderable import Renderable
-from src.core.types.color import Color
+from ecs.world import World
+from ecs.entities.apple import Apple
+from ecs.components.position import Position
+from ecs.components.edible import Edible
+from ecs.components.renderable import Renderable
+from core.types.color import Color
 
 
 def create_apple(

--- a/src/ecs/prefabs/obstacle_field.py
+++ b/src/ecs/prefabs/obstacle_field.py
@@ -22,13 +22,13 @@
 import random
 from typing import Optional, Literal
 
-from src.ecs.world import World
-from src.ecs.entities.obstacle_field import Obstacle
-from src.ecs.components.position import Position
-from src.ecs.components.obstacle import ObstacleTag
-from src.ecs.components.renderable import Renderable
-from src.core.types.color import Color
-from src.game import constants
+from ecs.world import World
+from ecs.entities.obstacle_field import Obstacle
+from ecs.components.position import Position
+from ecs.components.obstacle import ObstacleTag
+from ecs.components.renderable import Renderable
+from core.types.color import Color
+from game import constants
 
 
 DifficultyLevel = Literal["None", "Easy", "Medium", "Hard", "Impossible"]
@@ -156,7 +156,7 @@ def _get_occupied_cells(world: World) -> set[tuple[int, int]]:
             occupied.add((pos.x, pos.y))
 
     # also include snake body segments if snake has body component
-    from src.ecs.entities.entity import EntityType
+    from ecs.entities.entity import EntityType
 
     snakes = registry.query_by_type(EntityType.SNAKE)
     for _snake_id, snake in snakes.items():

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -20,14 +20,14 @@
 
 from typing import Optional
 
-from src.ecs.world import World
-from src.ecs.entities.snake import Snake
-from src.ecs.components.position import Position
-from src.ecs.components.velocity import Velocity
-from src.ecs.components.snake_body import SnakeBody
-from src.ecs.components.interpolation import Interpolation
-from src.ecs.components.renderable import Renderable
-from src.core.types.color import Color
+from ecs.world import World
+from ecs.entities.snake import Snake
+from ecs.components.position import Position
+from ecs.components.velocity import Velocity
+from ecs.components.snake_body import SnakeBody
+from ecs.components.interpolation import Interpolation
+from ecs.components.renderable import Renderable
+from core.types.color import Color
 
 
 def create_snake(

--- a/src/ecs/systems/apple_spawn.py
+++ b/src/ecs/systems/apple_spawn.py
@@ -28,10 +28,10 @@ from __future__ import annotations
 import random
 from typing import Optional
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.entities.entity import EntityType
-from src.ecs.prefabs.apple import create_apple
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
+from ecs.prefabs.apple import create_apple
 
 
 class AppleSpawnSystem(BaseSystem):

--- a/src/ecs/systems/assets.py
+++ b/src/ecs/systems/assets.py
@@ -21,8 +21,8 @@
 
 import pygame
 from typing import Optional
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
 
 
 class AssetsSystem(BaseSystem):

--- a/src/ecs/systems/audio.py
+++ b/src/ecs/systems/audio.py
@@ -32,9 +32,9 @@ from __future__ import annotations
 from typing import Optional, Dict
 import pygame
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.game.services.sfx_queue_service import SfxQueueService
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from game.services.sfx_queue_service import SfxQueueService
 
 
 class AudioSystem(BaseSystem):

--- a/src/ecs/systems/base_system.py
+++ b/src/ecs/systems/base_system.py
@@ -19,7 +19,7 @@
 
 
 from abc import ABC, abstractmethod
-from src.ecs.world import World
+from ecs.world import World
 
 
 class BaseSystem(ABC):

--- a/src/ecs/systems/board_render.py
+++ b/src/ecs/systems/board_render.py
@@ -30,11 +30,11 @@ Snake rendering is handled by SnakeRenderSystem.
 """
 
 import pygame
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.board import Tile
-from src.core.rendering.pygame_surface_renderer import RenderEnqueue
-from src.ecs.components.color_scheme import ColorScheme
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.board import Tile
+from core.rendering.pygame_surface_renderer import RenderEnqueue
+from ecs.components.color_scheme import ColorScheme
 
 
 class BoardRenderSystem(BaseSystem):
@@ -172,7 +172,7 @@ class BoardRenderSystem(BaseSystem):
             world: Game world to render
         """
         # Check if game is over - render only background if dead
-        from src.ecs.entities.entity import EntityType
+        from ecs.entities.entity import EntityType
 
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         game_over = False

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -30,8 +30,8 @@ Follows proper ECS architecture by querying world directly.
 
 from typing import Optional, Any
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
 
 
 class CollisionSystem(BaseSystem):
@@ -115,7 +115,7 @@ class CollisionSystem(BaseSystem):
         Returns:
             Snake entity or None if not found
         """
-        from src.ecs.entities.entity import EntityType
+        from ecs.entities.entity import EntityType
 
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
@@ -246,7 +246,7 @@ class CollisionSystem(BaseSystem):
         current_y = snake.position.y
 
         # query all obstacles
-        from src.ecs.entities.entity import EntityType
+        from ecs.entities.entity import EntityType
 
         obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
 
@@ -278,7 +278,7 @@ class CollisionSystem(BaseSystem):
         head_y = snake.position.y
 
         # query apples from world
-        from src.ecs.entities.entity import EntityType
+        from ecs.entities.entity import EntityType
 
         apples = world.registry.query_by_type(EntityType.APPLE)
         for entity_id, apple in apples.items():

--- a/src/ecs/systems/entity_render.py
+++ b/src/ecs/systems/entity_render.py
@@ -24,11 +24,11 @@ components rather than their type, making it fully data-driven.
 """
 
 import pygame
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.components.position import Position
-from src.ecs.components.renderable import Renderable
-from src.core.rendering.pygame_surface_renderer import RenderEnqueue
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.components.position import Position
+from ecs.components.renderable import Renderable
+from core.rendering.pygame_surface_renderer import RenderEnqueue
 
 
 class EntityRenderSystem(BaseSystem):
@@ -95,7 +95,7 @@ class EntityRenderSystem(BaseSystem):
         Args:
             world: Game world to render
         """
-        from src.ecs.entities.entity import EntityType
+        from ecs.entities.entity import EntityType
 
         # Query all entities with Position and Renderable components
         # This is the ECS way - data-driven, not type-driven

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -27,8 +27,8 @@ from typing import Optional, Any
 
 import pygame
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
 
 
 class InputSystem(BaseSystem):
@@ -138,7 +138,7 @@ class InputSystem(BaseSystem):
         Returns:
             Snake entity or None if not found
         """
-        from src.ecs.entities.entity import EntityType
+        from ecs.entities.entity import EntityType
 
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():

--- a/src/ecs/systems/interpolation.py
+++ b/src/ecs/systems/interpolation.py
@@ -26,8 +26,8 @@ the Interpolation component used by the RenderSystem.
 
 from __future__ import annotations
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
 
 
 class InterpolationSystem(BaseSystem):
@@ -66,7 +66,7 @@ class InterpolationSystem(BaseSystem):
         Args:
             world: ECS world containing entities and components
         """
-        from src.ecs.entities.entity import EntityType
+        from ecs.entities.entity import EntityType
 
         # get delta time from world (set by GameplayScene each frame)
         dt_ms = world.dt_ms

--- a/src/ecs/systems/movement.py
+++ b/src/ecs/systems/movement.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 
 from typing import Optional, Callable
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.entities.entity import EntityType
-from src.ecs.components.position import Position
-from src.ecs.components.velocity import Velocity
-from src.ecs.components.snake_body import SnakeBody
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
+from ecs.components.position import Position
+from ecs.components.velocity import Velocity
+from ecs.components.snake_body import SnakeBody
 
 
 class MovementSystem(BaseSystem):

--- a/src/ecs/systems/obstacle_generation.py
+++ b/src/ecs/systems/obstacle_generation.py
@@ -31,12 +31,12 @@ from __future__ import annotations
 import random
 from typing import Optional
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.entities.obstacle_field import Obstacle as ObstacleEntity
-from src.ecs.components.position import Position
-from src.ecs.components.obstacle import ObstacleTag
-from src.game import constants
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.obstacle_field import Obstacle as ObstacleEntity
+from ecs.components.position import Position
+from ecs.components.obstacle import ObstacleTag
+from game import constants
 
 
 # grid directions (up, down, left, right)

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -24,11 +24,11 @@ overlay rendering (pause screen, settings menu) on top of the game.
 """
 
 import pygame
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.core.rendering.pygame_surface_renderer import RenderEnqueue
-from src.core.types.color import Color
-from src.game import constants
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from core.rendering.pygame_surface_renderer import RenderEnqueue
+from core.types.color import Color
+from game import constants
 
 
 class OverlayRenderSystem(BaseSystem):

--- a/src/ecs/systems/scoring.py
+++ b/src/ecs/systems/scoring.py
@@ -26,8 +26,8 @@ across game resets and settings changes.
 
 from __future__ import annotations
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
 
 
 class ScoringSystem(BaseSystem):

--- a/src/ecs/systems/settings_apply.py
+++ b/src/ecs/systems/settings_apply.py
@@ -25,9 +25,9 @@ and entities in real-time during gameplay.
 
 from typing import Any, Optional
 import pygame
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.entities.entity import EntityType
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
 
 
 class SettingsApplySystem(BaseSystem):
@@ -158,7 +158,7 @@ class SettingsApplySystem(BaseSystem):
         new_height_cells = new_height_pixels // new_cell_size
 
         # create a new board with the new dimensions
-        from src.ecs.board import Board
+        from ecs.board import Board
 
         new_board = Board(
             width=new_width_cells, height=new_height_cells, cell_size=new_cell_size
@@ -211,7 +211,7 @@ class SettingsApplySystem(BaseSystem):
         tail_color_hex = snake_colors.get("tail")
 
         # convert hex colors to Color objects
-        from src.core.types.color import Color
+        from core.types.color import Color
 
         head_color = Color.from_hex(head_color_hex)
         tail_color = Color.from_hex(tail_color_hex)
@@ -331,7 +331,7 @@ class SettingsApplySystem(BaseSystem):
 
         # generate new obstacles if difficulty is not "None"
         if new_difficulty and new_difficulty != "None":
-            from src.ecs.prefabs.obstacle_field import create_obstacles
+            from ecs.prefabs.obstacle_field import create_obstacles
 
             grid_size = world.board.cell_size
 

--- a/src/ecs/systems/snake_render.py
+++ b/src/ecs/systems/snake_render.py
@@ -24,16 +24,16 @@ snake rendering with smooth interpolation effects.
 """
 
 import pygame
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.entities.entity import EntityType
-from src.ecs.components.position import Position
-from src.ecs.components.snake_body import SnakeBody
-from src.ecs.components.interpolation import Interpolation
-from src.ecs.components.color_scheme import ColorScheme
-from src.core.rendering.pygame_surface_renderer import RenderEnqueue
-from src.core.types.color import Color
-from src.game import constants
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
+from ecs.components.position import Position
+from ecs.components.snake_body import SnakeBody
+from ecs.components.interpolation import Interpolation
+from ecs.components.color_scheme import ColorScheme
+from core.rendering.pygame_surface_renderer import RenderEnqueue
+from core.types.color import Color
+from game import constants
 
 
 class SnakeRenderSystem(BaseSystem):

--- a/src/ecs/systems/spawn.py
+++ b/src/ecs/systems/spawn.py
@@ -28,10 +28,10 @@ from __future__ import annotations
 import random
 from typing import Optional
 
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.entities.entity import EntityType
-from src.ecs.prefabs.apple import create_apple
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
+from ecs.prefabs.apple import create_apple
 
 
 class SpawnSystem(BaseSystem):

--- a/src/ecs/systems/ui/command_converter.py
+++ b/src/ecs/systems/ui/command_converter.py
@@ -21,7 +21,7 @@
 
 import pygame
 from typing import Optional, Tuple, Callable
-from src.game.commands import (
+from game.commands import (
     Command,
     MoveCommand,
     PauseCommand,

--- a/src/ecs/systems/ui/menu_handler.py
+++ b/src/ecs/systems/ui/menu_handler.py
@@ -22,8 +22,8 @@
 
 import pygame
 from enum import Enum
-from src.core.rendering.pygame_surface_renderer import RenderEnqueue
-from src.ecs.systems.assets import AssetsSystem
+from core.rendering.pygame_surface_renderer import RenderEnqueue
+from ecs.systems.assets import AssetsSystem
 
 
 class StartDecision(Enum):

--- a/src/ecs/systems/ui/settings_handler.py
+++ b/src/ecs/systems/ui/settings_handler.py
@@ -21,8 +21,8 @@
 """Settings menu handler for game configuration."""
 
 import pygame
-from src.core.rendering.pygame_surface_renderer import RenderEnqueue
-from src.ecs.systems.assets import AssetsSystem
+from core.rendering.pygame_surface_renderer import RenderEnqueue
+from ecs.systems.assets import AssetsSystem
 
 
 class SettingsResult:

--- a/src/ecs/systems/ui_render.py
+++ b/src/ecs/systems/ui_render.py
@@ -24,12 +24,12 @@ basic HUD element rendering (score, speed bar, music indicator).
 """
 
 import pygame
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.world import World
-from src.ecs.entities.entity import EntityType
-from src.core.rendering.pygame_surface_renderer import RenderEnqueue
-from src.core.types.color import Color
-from src.game import constants
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
+from core.rendering.pygame_surface_renderer import RenderEnqueue
+from core.types.color import Color
+from game import constants
 
 
 class UIRenderSystem(BaseSystem):

--- a/src/ecs/world.py
+++ b/src/ecs/world.py
@@ -20,8 +20,8 @@
 """World composition class containing game state components."""
 
 import pygame
-from src.ecs.entity_registry import EntityRegistry
-from src.ecs.board import Board
+from ecs.entity_registry import EntityRegistry
+from ecs.board import Board
 
 __all__ = ["World"]
 

--- a/src/game/scenes/base_scene.py
+++ b/src/game/scenes/base_scene.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from src.core.io.pygame_adapter import PygameIOAdapter
-from src.core.rendering.pygame_surface_renderer import RenderEnqueue
+from core.io.pygame_adapter import PygameIOAdapter
+from core.rendering.pygame_surface_renderer import RenderEnqueue
 
 
 class BaseScene(ABC):

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -44,9 +44,9 @@ import pygame
 import sys
 from typing import Optional
 
-from src.game.scenes.base_scene import BaseScene
-from src.game.services.assets import GameAssets
-from src.game.constants import ARENA_COLOR
+from game.scenes.base_scene import BaseScene
+from game.services.assets import GameAssets
+from game.constants import ARENA_COLOR
 
 
 class GameOverScene(BaseScene):

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -25,26 +25,26 @@ work together harmoniously.
 
 from typing import Optional, Any, List
 
-from src.game.scenes.base_scene import BaseScene
-from src.game.services.game_initializer import GameInitializer
-from src.game.services.audio_service import AudioService
-from src.game.services.sfx_queue_service import SfxQueueService
-from src.ecs.world import World
-from src.ecs.systems.base_system import BaseSystem
-from src.ecs.systems.input import InputSystem
-from src.ecs.systems.movement import MovementSystem
-from src.ecs.systems.collision import CollisionSystem
-from src.ecs.systems.spawn import SpawnSystem
-from src.ecs.systems.scoring import ScoringSystem
-from src.ecs.systems.audio import AudioSystem
-from src.ecs.systems.interpolation import InterpolationSystem
-from src.ecs.systems.board_render import BoardRenderSystem
-from src.ecs.systems.snake_render import SnakeRenderSystem
-from src.ecs.systems.entity_render import EntityRenderSystem
-from src.ecs.systems.ui_render import UIRenderSystem
-from src.ecs.systems.overlay_render import OverlayRenderSystem
-from src.ecs.systems.obstacle_generation import ObstacleGenerationSystem
-from src.ecs.systems.settings_apply import SettingsApplySystem
+from game.scenes.base_scene import BaseScene
+from game.services.game_initializer import GameInitializer
+from game.services.audio_service import AudioService
+from game.services.sfx_queue_service import SfxQueueService
+from ecs.world import World
+from ecs.systems.base_system import BaseSystem
+from ecs.systems.input import InputSystem
+from ecs.systems.movement import MovementSystem
+from ecs.systems.collision import CollisionSystem
+from ecs.systems.spawn import SpawnSystem
+from ecs.systems.scoring import ScoringSystem
+from ecs.systems.audio import AudioSystem
+from ecs.systems.interpolation import InterpolationSystem
+from ecs.systems.board_render import BoardRenderSystem
+from ecs.systems.snake_render import SnakeRenderSystem
+from ecs.systems.entity_render import EntityRenderSystem
+from ecs.systems.ui_render import UIRenderSystem
+from ecs.systems.overlay_render import OverlayRenderSystem
+from ecs.systems.obstacle_generation import ObstacleGenerationSystem
+from ecs.systems.settings_apply import SettingsApplySystem
 
 
 class GameplayScene(BaseScene):
@@ -106,7 +106,7 @@ class GameplayScene(BaseScene):
         self._systems.clear()
 
         # game logic systems (indices 0-7, paused during pause)
-        from src.ecs.systems.apple_spawn import AppleSpawnSystem
+        from ecs.systems.apple_spawn import AppleSpawnSystem
 
         self._systems.extend(
             [

--- a/src/game/scenes/menu.py
+++ b/src/game/scenes/menu.py
@@ -43,10 +43,10 @@ from __future__ import annotations
 import pygame
 from typing import Optional
 
-from src.game.scenes.base_scene import BaseScene
-from src.game.services.assets import GameAssets
-from src.game.settings import GameSettings
-from src.game.constants import ARENA_COLOR, MESSAGE_COLOR, SCORE_COLOR, WINDOW_TITLE
+from game.scenes.base_scene import BaseScene
+from game.services.assets import GameAssets
+from game.settings import GameSettings
+from game.constants import ARENA_COLOR, MESSAGE_COLOR, SCORE_COLOR, WINDOW_TITLE
 
 
 class MenuScene(BaseScene):

--- a/src/game/scenes/scene_manager.py
+++ b/src/game/scenes/scene_manager.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
-from src.game.scenes.base_scene import BaseScene
+from game.scenes.base_scene import BaseScene
 
 
 class SceneManager:

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -24,10 +24,10 @@ from __future__ import annotations
 import pygame
 from typing import Optional
 
-from src.game.scenes.base_scene import BaseScene
-from src.game.services.assets import GameAssets
-from src.game.settings import GameSettings
-from src.game.constants import ARENA_COLOR, MESSAGE_COLOR, SCORE_COLOR, GRID_COLOR
+from game.scenes.base_scene import BaseScene
+from game.services.assets import GameAssets
+from game.settings import GameSettings
+from game.constants import ARENA_COLOR, MESSAGE_COLOR, SCORE_COLOR, GRID_COLOR
 
 
 class SettingsScene(BaseScene):

--- a/src/game/services/__init__.py
+++ b/src/game/services/__init__.py
@@ -19,7 +19,7 @@
 
 """Services module."""
 
-from src.game.services.game_initializer import GameInitializer
-from src.game.services.sfx_queue_service import SfxQueueService
+from game.services.game_initializer import GameInitializer
+from game.services.sfx_queue_service import SfxQueueService
 
 __all__ = ["GameInitializer", "SfxQueueService"]

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -25,8 +25,8 @@ creating initial entities, and managing game state transitions.
 import random
 from typing import Any, Optional
 
-from src.ecs.world import World
-from src.core.types.color_utils import hex_to_rgb
+from ecs.world import World
+from core.types.color_utils import hex_to_rgb
 
 
 class GameInitializer:
@@ -119,7 +119,7 @@ class GameInitializer:
         Args:
             world: ECS world instance
         """
-        from src.ecs.components.game_state import GameState
+        from ecs.components.game_state import GameState
 
         class GameStateEntity:
             def __init__(self):
@@ -145,7 +145,7 @@ class GameInitializer:
         Args:
             world: ECS world instance
         """
-        from src.ecs.components.color_scheme import ColorScheme
+        from ecs.components.color_scheme import ColorScheme
 
         class ColorSchemeEntity:
             def __init__(self):
@@ -164,7 +164,7 @@ class GameInitializer:
             world: ECS world instance
             grid_size: Size of grid cells in pixels
         """
-        from src.ecs.prefabs.snake import create_snake
+        from ecs.prefabs.snake import create_snake
 
         # get snake colors from settings
         snake_colors = self._settings.get_snake_colors()
@@ -189,7 +189,7 @@ class GameInitializer:
         Args:
             world: ECS world instance
         """
-        from src.ecs.components.apple_config import AppleConfig
+        from ecs.components.apple_config import AppleConfig
 
         class AppleConfigEntity:
             def __init__(self, desired_count: int):
@@ -213,8 +213,8 @@ class GameInitializer:
             world: ECS world instance
             grid_size: Size of grid cells in pixels
         """
-        from src.ecs.prefabs.apple import create_apple
-        from src.ecs.entities.entity import EntityType
+        from ecs.prefabs.apple import create_apple
+        from ecs.entities.entity import EntityType
 
         # get desired apple count from config entity
         apple_configs = world.registry.query_by_component("apple_config")
@@ -259,7 +259,7 @@ class GameInitializer:
         """
         difficulty = self._settings.get("obstacle_difficulty")
         if difficulty and difficulty != "None":
-            from src.ecs.prefabs.obstacle_field import create_obstacles
+            from ecs.prefabs.obstacle_field import create_obstacles
 
             _ = create_obstacles(
                 world=world,
@@ -274,7 +274,7 @@ class GameInitializer:
         Args:
             world: ECS world instance
         """
-        from src.ecs.components.score import Score
+        from ecs.components.score import Score
 
         # create a simple object to hold the score component
         # we don't use a specific entity type since this is just for UI tracking

--- a/tests/core/rendering/test_pygame_surface_renderer.py
+++ b/tests/core/rendering/test_pygame_surface_renderer.py
@@ -22,7 +22,7 @@
 import pytest
 import pygame
 from unittest.mock import Mock, MagicMock, patch
-from src.core.rendering.pygame_surface_renderer import (
+from core.rendering.pygame_surface_renderer import (
     PygameSurfaceRenderer,
     _RendererView,
     DrawCommand,

--- a/tests/ecs/systems/test_assets_system.py
+++ b/tests/ecs/systems/test_assets_system.py
@@ -22,9 +22,9 @@
 import pytest
 import pygame
 from unittest.mock import patch, MagicMock
-from src.ecs.systems.assets import AssetsSystem
-from src.ecs.world import World
-from src.ecs.board import Board
+from ecs.systems.assets import AssetsSystem
+from ecs.world import World
+from ecs.board import Board
 
 
 @pytest.fixture(scope="module")
@@ -74,7 +74,7 @@ class TestAssetsSystemInitialization:
 
     def test_inherits_from_base_system(self, assets_system):
         """Test that AssetsSystem inherits from BaseSystem."""
-        from src.ecs.systems.base_system import BaseSystem
+        from ecs.systems.base_system import BaseSystem
 
         assert isinstance(assets_system, BaseSystem)
 

--- a/tests/ecs/systems/test_collision_system.py
+++ b/tests/ecs/systems/test_collision_system.py
@@ -22,9 +22,9 @@
 import pytest
 from unittest.mock import Mock
 
-from src.ecs.systems.collision import CollisionSystem
-from src.ecs.world import World
-from src.ecs.board import Board
+from ecs.systems.collision import CollisionSystem
+from ecs.world import World
+from ecs.board import Board
 
 
 @pytest.fixture

--- a/tests/ecs/systems/test_input_system.py
+++ b/tests/ecs/systems/test_input_system.py
@@ -23,9 +23,9 @@ import pytest
 from unittest.mock import Mock
 import pygame
 
-from src.ecs.systems.input import InputSystem
-from src.ecs.world import World
-from src.ecs.board import Board
+from ecs.systems.input import InputSystem
+from ecs.world import World
+from ecs.board import Board
 
 
 @pytest.fixture

--- a/tests/ecs/systems/test_ui_system.py
+++ b/tests/ecs/systems/test_ui_system.py
@@ -21,15 +21,15 @@
 
 import pytest
 from unittest.mock import Mock
-from src.ecs.systems.ui import (
+from ecs.systems.ui import (
     UISystem,
     StartDecision,
     SettingsResult,
     ResetDecision,
     GameOverDecision,
 )
-from src.ecs.systems.assets import AssetsSystem
-from src.ecs.world import World
+from ecs.systems.assets import AssetsSystem
+from ecs.world import World
 
 
 class MockRenderEnqueue:
@@ -126,7 +126,7 @@ class TestUISystemInitialization:
 
     def test_inherits_from_base_system(self, ui_system):
         """Test UISystem inherits from BaseSystem."""
-        from src.ecs.systems.base_system import BaseSystem
+        from ecs.systems.base_system import BaseSystem
 
         assert isinstance(ui_system, BaseSystem)
 

--- a/tests/ecs/test_audio_system.py
+++ b/tests/ecs/test_audio_system.py
@@ -23,10 +23,10 @@ import pytest
 from dataclasses import dataclass
 from unittest.mock import Mock, patch
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.systems.audio import AudioSystem
-from src.game.services.sfx_queue_service import SfxQueueService
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.audio import AudioSystem
+from game.services.sfx_queue_service import SfxQueueService
 
 
 @dataclass

--- a/tests/ecs/test_board.py
+++ b/tests/ecs/test_board.py
@@ -20,7 +20,7 @@
 """Board class tests."""
 
 import pytest
-from src.ecs.board import Board, Tile, BoardOutOfBoundsError
+from ecs.board import Board, Tile, BoardOutOfBoundsError
 
 
 class TestBoardInitialization:

--- a/tests/ecs/test_command_protocol.py
+++ b/tests/ecs/test_command_protocol.py
@@ -21,7 +21,7 @@
 """Unit tests for command protocol."""
 
 import pytest
-from src.game.commands import (
+from game.commands import (
     MoveCommand,
     PauseCommand,
     QuitCommand,

--- a/tests/ecs/test_components.py
+++ b/tests/ecs/test_components.py
@@ -19,8 +19,8 @@
 
 """Component data tests."""
 
-from src.ecs.components import Position, Renderable, Interpolation, Grid
-from src.core.types.color import Color
+from ecs.components import Position, Renderable, Interpolation, Grid
+from core.types.color import Color
 
 
 class TestVisualComponents:

--- a/tests/ecs/test_entity_registry.py
+++ b/tests/ecs/test_entity_registry.py
@@ -20,9 +20,9 @@
 """EntityRegistry class tests."""
 
 import pytest
-from src.ecs.entity_registry import EntityRegistry
-from src.ecs.entities import Snake, Apple, Obstacle, EntityType
-from src.ecs.components import (
+from ecs.entity_registry import EntityRegistry
+from ecs.entities import Snake, Apple, Obstacle, EntityType
+from ecs.components import (
     Position,
     Velocity,
     SnakeBody,

--- a/tests/ecs/test_interpolation_system.py
+++ b/tests/ecs/test_interpolation_system.py
@@ -22,9 +22,9 @@
 import pytest
 from dataclasses import dataclass
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.systems.interpolation import InterpolationSystem
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.interpolation import InterpolationSystem
 
 
 @dataclass

--- a/tests/ecs/test_obstacle_generation_system.py
+++ b/tests/ecs/test_obstacle_generation_system.py
@@ -21,10 +21,10 @@
 
 import pytest
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.systems.obstacle_generation import ObstacleGenerationSystem
-from src.ecs.entities.entity import EntityType
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.obstacle_generation import ObstacleGenerationSystem
+from ecs.entities.entity import EntityType
 
 
 @pytest.fixture

--- a/tests/ecs/test_prefabs.py
+++ b/tests/ecs/test_prefabs.py
@@ -19,12 +19,12 @@
 
 """Tests for entity prefab factories."""
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.entities.entity import EntityType
-from src.ecs.prefabs.snake import create_snake
-from src.ecs.prefabs.apple import create_apple
-from src.ecs.prefabs.obstacle_field import create_obstacles
+from ecs.world import World
+from ecs.board import Board
+from ecs.entities.entity import EntityType
+from ecs.prefabs.snake import create_snake
+from ecs.prefabs.apple import create_apple
+from ecs.prefabs.obstacle_field import create_obstacles
 
 
 class TestSnakePrefab:

--- a/tests/ecs/test_resize_system.py
+++ b/tests/ecs/test_resize_system.py
@@ -22,9 +22,9 @@
 import pytest
 from unittest.mock import Mock
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.systems.resize import ResizeSystem
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.resize import ResizeSystem
 
 
 @pytest.fixture

--- a/tests/ecs/test_scoring_system.py
+++ b/tests/ecs/test_scoring_system.py
@@ -22,9 +22,9 @@
 import pytest
 from dataclasses import dataclass
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.systems.scoring import ScoringSystem
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.scoring import ScoringSystem
 
 
 @dataclass

--- a/tests/ecs/test_settings_application.py
+++ b/tests/ecs/test_settings_application.py
@@ -22,7 +22,7 @@
 
 import pytest
 from unittest.mock import Mock, patch
-from src.ecs.systems.ui import SettingsApplicator
+from ecs.systems.ui import SettingsApplicator
 
 
 class TestSettingsApplicator:

--- a/tests/ecs/test_snake_render.py
+++ b/tests/ecs/test_snake_render.py
@@ -20,15 +20,15 @@
 """Tests for snake rendering with interpolation."""
 
 import pytest
-from src.ecs.entities.snake import Snake
-from src.ecs.components.position import Position
-from src.ecs.components.velocity import Velocity
-from src.ecs.components.snake_body import SnakeBody
-from src.ecs.components.interpolation import Interpolation
-from src.ecs.components.renderable import Renderable
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.systems.board_render import BoardRenderSystem
+from ecs.entities.snake import Snake
+from ecs.components.position import Position
+from ecs.components.velocity import Velocity
+from ecs.components.snake_body import SnakeBody
+from ecs.components.interpolation import Interpolation
+from ecs.components.renderable import Renderable
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.board_render import BoardRenderSystem
 
 
 class MockRenderer:

--- a/tests/ecs/test_spawn_system.py
+++ b/tests/ecs/test_spawn_system.py
@@ -21,17 +21,17 @@
 
 import pytest
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.ecs.systems.spawn import SpawnSystem
-from src.ecs.entities.snake import Snake
-from src.ecs.entities.entity import EntityType
-from src.ecs.components.position import Position
-from src.ecs.components.velocity import Velocity
-from src.ecs.components.snake_body import SnakeBody
-from src.ecs.components.interpolation import Interpolation
-from src.ecs.components.renderable import Renderable
-from src.core.types.color import Color
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.spawn import SpawnSystem
+from ecs.entities.snake import Snake
+from ecs.entities.entity import EntityType
+from ecs.components.position import Position
+from ecs.components.velocity import Velocity
+from ecs.components.snake_body import SnakeBody
+from ecs.components.interpolation import Interpolation
+from ecs.components.renderable import Renderable
+from core.types.color import Color
 
 
 @pytest.fixture

--- a/tests/game/test_gameplay_scene.py
+++ b/tests/game/test_gameplay_scene.py
@@ -21,18 +21,18 @@
 
 import pytest
 
-from src.ecs.world import World
-from src.ecs.board import Board
-from src.game.scenes.gameplay import GameplayScene
-from src.ecs.systems.input import InputSystem
-from src.ecs.systems.movement import MovementSystem
-from src.ecs.systems.collision import CollisionSystem
-from src.ecs.systems.spawn import SpawnSystem
-from src.ecs.systems.scoring import ScoringSystem
-from src.ecs.systems.audio import AudioSystem
-from src.ecs.systems.interpolation import InterpolationSystem
-from src.ecs.systems.board_render import BoardRenderSystem
-from src.ecs.systems.obstacle_generation import ObstacleGenerationSystem
+from ecs.world import World
+from ecs.board import Board
+from game.scenes.gameplay import GameplayScene
+from ecs.systems.input import InputSystem
+from ecs.systems.movement import MovementSystem
+from ecs.systems.collision import CollisionSystem
+from ecs.systems.spawn import SpawnSystem
+from ecs.systems.scoring import ScoringSystem
+from ecs.systems.audio import AudioSystem
+from ecs.systems.interpolation import InterpolationSystem
+from ecs.systems.board_render import BoardRenderSystem
+from ecs.systems.obstacle_generation import ObstacleGenerationSystem
 
 
 class TestGameplayScene:

--- a/uv.lock
+++ b/uv.lock
@@ -105,7 +105,7 @@ wheels = [
 [[package]]
 name = "naja"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "pygame" },
 ]


### PR DESCRIPTION
As it is right now, the project is not a valid python package. The main file being outside `src` is out of standard, and it was missing a proper entrypoint.

This PR:

1. Moves the `main` function from `cobra.py` to `src/core/__init__.py`
2. Adds a proper `__main__.py` that calls it
3. Fixes imports, which should be relative to `src` according to standard
4. Adds an entrypoint, which allows for `pip install .` and `uv run naja` (and corresponding updated docs)
5. Correctly marks the project as installable

Some implications: users can now use standard tooling with the project. For example, `pipx install https://github.com/fossguild/naja` can install the program directly.