### PR TITLE
feat(ci): use black and ruff from uv.lock

### DIFF
--- a/.github/workflows/ci-lint-fmt.yml
+++ b/.github/workflows/ci-lint-fmt.yml
@@ -7,10 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - uses: astral-sh/setup-uv@v6
+      - run: uv tool run black . --check --diff
+
   ruff:
     name: runner / ruff linter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/setup-uv@v6
+      - run: uv tool run ruff check


### PR DESCRIPTION
As it is right now, the CI uses out-of-band versions of black and ruff. We should use UV to run them, to ensure they are always the locked version. This has bit me in the past in other projects.