### PR TITLE
code: add game modes menu with classic and random options

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -32,6 +32,7 @@ from ecs.prefabs.apple import create_apple
 from ecs.prefabs.obstacle_field import create_obstacles
 from game.scenes.scene_manager import SceneManager
 from game.scenes.menu import MenuScene
+from game.scenes.game_modes import GameModesScene
 from game.scenes.gameplay import GameplayScene
 from game.scenes.game_over import GameOverScene
 from game.scenes.settings import SettingsScene
@@ -132,6 +133,17 @@ class ECSGameApp:
             settings=self.settings,
         )
         self.scene_manager.register_scene("menu", menu_scene)
+
+        # Game modes scene
+        game_modes_scene = GameModesScene(
+            pygame_adapter=self.pygame_adapter,
+            renderer=self.renderer.view(),
+            width=self.config.initial_width,
+            height=self.config.initial_height,
+            assets=self.assets,
+            settings=self.settings,
+        )
+        self.scene_manager.register_scene("game_modes", game_modes_scene)
 
         # Settings scene
         settings_scene = SettingsScene(

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Game modes menu scene."""
+
+from __future__ import annotations
+
+import pygame
+import random
+from typing import Optional
+
+from game.scenes.base_scene import BaseScene
+from game.services.assets import GameAssets
+from game.settings import GameSettings
+from game.constants import ARENA_COLOR, MESSAGE_COLOR, SCORE_COLOR
+
+# global variable to store selected game mode
+_selected_game_mode = 0  # 0 = Classic, 1 = Random
+
+# Available actual game modes (not including random)
+ACTUAL_GAME_MODES = [
+    "Classic Snake Game",
+    # Future modes will be added here:
+    # "More Fruits",
+    # "Poisoned Apple",
+    # "Flying Apple",
+    # etc.
+]
+
+
+def get_selected_game_mode() -> int:
+    """Get the currently selected game mode.
+
+    Returns:
+        Index of selected game mode (0=Classic, 1=Random)
+    """
+    return _selected_game_mode
+
+
+def set_selected_game_mode(mode: int) -> None:
+    """Set the selected game mode.
+
+    Args:
+        mode: Index of game mode to select (0=Classic, 1=Random)
+    """
+    global _selected_game_mode
+    _selected_game_mode = mode
+
+
+def get_resolved_game_mode() -> str:
+    """Get the actual game mode to play.
+
+    If Random is selected, picks a random actual game mode.
+    Otherwise returns the selected mode name.
+
+    Returns:
+        Name of the actual game mode to play
+    """
+    if _selected_game_mode == 1:  # Random mode
+        return random.choice(ACTUAL_GAME_MODES)
+    else:  # Classic or other direct modes
+        return ACTUAL_GAME_MODES[0]  # For now, only Classic exists
+
+
+def get_display_mode_name() -> str:
+    """Get the display name for the selected mode.
+
+    Returns:
+        Display name showing what will be played
+    """
+    if _selected_game_mode == 0:
+        return "Classic Snake Game"
+    elif _selected_game_mode == 1:
+        return "🎲 Random"
+    else:
+        return "Classic Snake Game"
+
+
+class GameModesScene(BaseScene):
+    """Game modes selection menu."""
+
+    def __init__(
+        self,
+        pygame_adapter,
+        renderer,
+        width: int,
+        height: int,
+        assets: GameAssets,
+        settings: GameSettings,
+    ):
+        """Initialize the game modes scene.
+
+        Args:
+            pygame_adapter: Pygame IO adapter
+            renderer: Renderer for drawing
+            width: Scene width
+            height: Scene height
+            assets: Game assets
+            settings: Game settings
+        """
+        super().__init__(pygame_adapter, renderer, width, height)
+        self._assets = assets
+        self._settings = settings
+        self._selected_index = 0
+        self._menu_items = ["Classic Snake Game", "🎲 Random"]
+
+    def update(self, dt_ms: float) -> Optional[str]:
+        """Update game modes menu logic."""
+        # Handle input
+        for event in self._pygame_adapter.get_events():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                exit()
+
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_UP, pygame.K_w):
+                    self._selected_index = (self._selected_index - 1) % len(
+                        self._menu_items
+                    )
+                elif event.key in (pygame.K_DOWN, pygame.K_s):
+                    self._selected_index = (self._selected_index + 1) % len(
+                        self._menu_items
+                    )
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    # save the selected game mode
+                    set_selected_game_mode(self._selected_index)
+                    # go back to main menu
+                    return "menu"
+                elif event.key == pygame.K_ESCAPE:
+                    # go back to main menu
+                    return "menu"
+
+        return None
+
+    def render(self) -> None:
+        """Render the game modes menu."""
+        # Clear screen
+        self._renderer.fill(ARENA_COLOR)
+
+        # Draw title
+        title = self._assets.render_custom(
+            "Game Modes", MESSAGE_COLOR, int(self._width / 15)
+        )
+        title_rect = title.get_rect(center=(self._width / 2, self._height / 4))
+        self._renderer.blit(title, title_rect)
+
+        # Draw menu items
+        for i, item in enumerate(self._menu_items):
+            color = SCORE_COLOR if i == self._selected_index else MESSAGE_COLOR
+
+            # add arrow indicator if this mode is selected (confirmed)
+            display_text = item
+            if i == get_selected_game_mode():
+                display_text = f">> {item} <<"
+
+            text = self._assets.render_small(display_text, color)
+            rect = text.get_rect(
+                center=(self._width / 2, self._height / 2 + i * (self._height * 0.12))
+            )
+            self._renderer.blit(text, rect)
+
+        # Draw description for selected mode
+        if self._selected_index == 1:  # Random mode
+            description = "Randomly selects a game mode"
+            desc_text = self._assets.render_custom(
+                description, (120, 120, 120), int(self._width / 45)
+            )
+            desc_rect = desc_text.get_rect(center=(self._width / 2, self._height * 0.7))
+            self._renderer.blit(desc_text, desc_rect)
+
+        # Draw back instruction
+        back_text = self._assets.render_custom(
+            "Press ESC to go back", MESSAGE_COLOR, int(self._width / 40)
+        )
+        back_rect = back_text.get_rect(
+            center=(self._width / 2, self._height - self._height * 0.1)
+        )
+        self._renderer.blit(back_text, back_rect)
+
+    def on_enter(self) -> None:
+        """Called when entering game modes menu."""
+        # start with cursor on currently selected game mode
+        self._selected_index = get_selected_game_mode()

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -181,7 +181,12 @@ class GameModesScene(BaseScene):
             desc_text = self._assets.render_custom(
                 description, (120, 120, 120), int(self._width / 45)
             )
-            desc_rect = desc_text.get_rect(center=(self._width / 2, self._height * 0.7))
+            desc_rect = desc_text.get_rect(
+                center=(
+                    self._width / 2,
+                    self._height / 2 + 1 * (self._height * 0.12) + self._height * 0.05,
+                )
+            )
             self._renderer.blit(desc_text, desc_rect)
 
         # Draw back instruction

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -140,6 +140,10 @@ class GameModesScene(BaseScene):
                 elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
                     # save the selected game mode
                     set_selected_game_mode(self._selected_index)
+                    # if Classic Snake Game is selected, reset settings to default
+                    if self._selected_index == 0:  # Classic mode
+                        self._settings.reset_to_defaults()
+                        self._settings.save_settings()
                     # go back to main menu
                     return "menu"
                 elif event.key == pygame.K_ESCAPE:

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -87,7 +87,7 @@ def get_display_mode_name() -> str:
     if _selected_game_mode == 0:
         return "Classic Snake Game"
     elif _selected_game_mode == 1:
-        return "🎲 Random"
+        return "Random"
     else:
         return "Classic Snake Game"
 

--- a/src/game/scenes/menu.py
+++ b/src/game/scenes/menu.py
@@ -75,7 +75,7 @@ class MenuScene(BaseScene):
         self._assets = assets
         self._settings = settings
         self._selected_index = 0
-        self._menu_items = ["Start Game", "Settings", "Quit"]
+        self._menu_items = ["Start Game", "Game Modes", "Settings", "Quit"]
 
     def update(self, dt_ms: float) -> Optional[str]:
         """Update menu logic.
@@ -104,6 +104,8 @@ class MenuScene(BaseScene):
                 elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
                     if self._menu_items[self._selected_index] == "Start Game":
                         return "gameplay"
+                    elif self._menu_items[self._selected_index] == "Game Modes":
+                        return "game_modes"
                     elif self._menu_items[self._selected_index] == "Settings":
                         return "settings"
                     elif self._menu_items[self._selected_index] == "Quit":
@@ -120,12 +122,22 @@ class MenuScene(BaseScene):
         # Clear screen
         self._renderer.fill(ARENA_COLOR)
 
-        # Draw title
+        # Draw title (bigger and more prominent)
         title = self._assets.render_custom(
-            WINDOW_TITLE, MESSAGE_COLOR, int(self._width / 12)
+            WINDOW_TITLE, MESSAGE_COLOR, int(self._width / 8)
         )
-        title_rect = title.get_rect(center=(self._width / 2, self._height / 4))
+        title_rect = title.get_rect(center=(self._width / 2, self._height / 5))
         self._renderer.blit(title, title_rect)
+
+        # Draw selected game mode below title
+        mode_text = self._get_selected_mode_text()
+        mode_surface = self._assets.render_custom(
+            mode_text, (150, 150, 150), int(self._width / 32)
+        )
+        mode_rect = mode_surface.get_rect(
+            center=(self._width / 2, self._height / 5 + self._height * 0.10)
+        )
+        self._renderer.blit(mode_surface, mode_rect)
 
         # Draw menu items
         for i, item in enumerate(self._menu_items):
@@ -144,3 +156,16 @@ class MenuScene(BaseScene):
         # (it might have stopped if coming from game over)
         if self._settings.get("background_music"):
             GameAssets.play_background_music(loop=True)
+
+    def _get_selected_mode_text(self) -> str:
+        """Get text for currently selected game mode.
+
+        Returns:
+            Display text for selected game mode
+        """
+        try:
+            from game.scenes.game_modes import get_display_mode_name
+
+            return get_display_mode_name()
+        except Exception:
+            return "Classic Snake Game"

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -59,6 +59,8 @@ class SettingsScene(BaseScene):
         self._settings = settings
         self._config = config
         self._selected_index = 0
+        # total menu items = settings fields + "Reset to Default" button
+        self._total_menu_items = len(self._settings.MENU_FIELDS) + 1
 
     def update(self, dt_ms: float) -> Optional[str]:
         """Update settings logic.
@@ -70,10 +72,12 @@ class SettingsScene(BaseScene):
             Next scene name or None
         """
         # Update key holding state (this handles continuous changes)
-        if self._settings.update_key_hold():
-            # A value was updated by key holding
-            current_field = self._settings.MENU_FIELDS[self._selected_index]
-            self._apply_audio_setting_if_changed(current_field["key"])
+        # Only update if not on "Reset to Default" button
+        if self._selected_index < len(self._settings.MENU_FIELDS):
+            if self._settings.update_key_hold():
+                # A value was updated by key holding
+                current_field = self._settings.MENU_FIELDS[self._selected_index]
+                self._apply_audio_setting_if_changed(current_field["key"])
 
         # Handle input
         for event in self._pygame_adapter.get_events():
@@ -82,34 +86,48 @@ class SettingsScene(BaseScene):
                 exit()
 
             elif event.type == pygame.KEYDOWN:
-                if event.key in (pygame.K_ESCAPE, pygame.K_RETURN):
+                if event.key == pygame.K_ESCAPE:
                     # Stop any ongoing key hold when leaving
                     self._settings.stop_key_hold()
                     return "menu"  # back to menu
+                elif event.key == pygame.K_RETURN:
+                    # Check if "Reset to Default" is selected
+                    if self._selected_index == len(self._settings.MENU_FIELDS):
+                        self._settings.reset_to_defaults()
+                        self._settings.save_settings()
+                        # Stay in settings to show the reset took effect
+                    else:
+                        # Regular return to menu
+                        self._settings.stop_key_hold()
+                        return "menu"
                 elif event.key in (pygame.K_DOWN, pygame.K_s):
                     # Stop key hold when changing selection
                     self._settings.stop_key_hold()
-                    self._selected_index = (self._selected_index + 1) % len(
-                        self._settings.MENU_FIELDS
-                    )
+                    self._selected_index = (
+                        self._selected_index + 1
+                    ) % self._total_menu_items
                 elif event.key in (pygame.K_UP, pygame.K_w):
                     # Stop key hold when changing selection
                     self._settings.stop_key_hold()
-                    self._selected_index = (self._selected_index - 1) % len(
-                        self._settings.MENU_FIELDS
-                    )
+                    self._selected_index = (
+                        self._selected_index - 1
+                    ) % self._total_menu_items
                 elif event.key in (pygame.K_LEFT, pygame.K_a):
-                    # Start holding left
-                    current_field = self._settings.MENU_FIELDS[self._selected_index]
-                    self._settings.start_key_hold(current_field, -1)
-                    # Apply audio settings immediately
-                    self._apply_audio_setting_if_changed(current_field["key"])
+                    # Only handle left/right on settings fields, not on "Reset to Default"
+                    if self._selected_index < len(self._settings.MENU_FIELDS):
+                        # Start holding left
+                        current_field = self._settings.MENU_FIELDS[self._selected_index]
+                        self._settings.start_key_hold(current_field, -1)
+                        # Apply audio settings immediately
+                        self._apply_audio_setting_if_changed(current_field["key"])
                 elif event.key in (pygame.K_RIGHT, pygame.K_d):
-                    # Start holding right
-                    current_field = self._settings.MENU_FIELDS[self._selected_index]
-                    self._settings.start_key_hold(current_field, +1)
-                    # Apply audio settings immediately
-                    self._apply_audio_setting_if_changed(current_field["key"])
+                    # Only handle left/right on settings fields, not on "Reset to Default"
+                    if self._selected_index < len(self._settings.MENU_FIELDS):
+                        # Start holding right
+                        current_field = self._settings.MENU_FIELDS[self._selected_index]
+                        self._settings.start_key_hold(current_field, +1)
+                        # Apply audio settings immediately
+                        self._apply_audio_setting_if_changed(current_field["key"])
 
             elif event.type == pygame.KEYUP:
                 # Stop holding when any left/right key is released
@@ -185,6 +203,20 @@ class SettingsScene(BaseScene):
             rect.left = int(self._width * 0.10)
             rect.top = padding_y + draw_i * row_h
             self._renderer.blit(text, rect)
+
+        # Draw "Reset to Default" button
+        reset_index = len(self._settings.MENU_FIELDS)
+        if reset_index >= top_index and (reset_index - top_index) < visible_rows:
+            draw_pos = reset_index - top_index
+            reset_text = self._assets.render_custom(
+                "Reset to Default",
+                SCORE_COLOR if self._selected_index == reset_index else MESSAGE_COLOR,
+                int(self._width / 30),
+            )
+            reset_rect = reset_text.get_rect()
+            reset_rect.left = int(self._width * 0.10)
+            reset_rect.top = padding_y + draw_pos * row_h
+            self._renderer.blit(reset_text, reset_rect)
 
         # Hint footer
         hint_text = "[A/D] change   [W/S] select   [Enter/Esc] back   [C] random colors"


### PR DESCRIPTION
## Description
Adds a new Game Modes selection screen accessible from the main menu. Users can choose between Classic Snake Game mode or Random mode (which randomly selects a game mode when starting). The selected mode is displayed with visual indicators (>> <<) in the game modes menu and shown below the title on the main menu.

## Related Issue
Closes #343

## Changes Made
- Added new `GameModesScene` with Classic and Random mode options
- Added "Game Modes" button to main menu (between Start Game and Settings)
- Implemented visual indicator (>> <<) for currently selected mode
- Display selected game mode below title on main menu
- Random mode infrastructure ready for future game mode additions
- Added mode description when hovering over Random option

## Screenshots
Main Menu with selected mode displayed:
- Selected game mode shown below title in gray text

<img width="832" height="824" alt="Screenshot 2025-11-16 at 10 47 06" src="https://github.com/user-attachments/assets/694e9330-3302-481b-a32d-9bbc163d0594" />


Game Modes Menu:
- Two options: "Classic Snake Game" and "Random"
- Visual indicator (>>) shows confirmed selection
- ESC returns to main menu

<img width="833" height="834" alt="Screenshot 2025-11-16 at 10 51 04" src="https://github.com/user-attachments/assets/230f1d28-ed20-4994-8bd4-f6b001598189" />