### PR TITLE
Dynamic Spawn Obstacle Mode Enabling

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+    "permissions": {
+      "allow": [
+        "Bash(mkdir:*)"
+      ],
+      "deny": [],
+      "ask": []
+    }
+  }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-    "permissions": {
-      "allow": [
-        "Bash(mkdir:*)"
-      ],
-      "deny": [],
-      "ask": []
-    }
-  }

--- a/docs/adr/0001-choose-ecs.md
+++ b/docs/adr/0001-choose-ecs.md
@@ -31,7 +31,7 @@ This pattern separates data from behavior, making each piece small, focused, and
 
 **Negative:**
 - ❌ More files/abstractions than traditional OOP
-- ❌ Learning curve for contributors 
+- ❌ Learning curve for contributors
 
 **Mitigations:**
 - Comprehensive documentation in `docs/architecture.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Naja ECS Architecture
 
-> **Version:** 1.0 
+> **Version:** 1.0
 > **Last Updated:** October 2025
 > **Status:** Fully Implemented
 
@@ -76,11 +76,11 @@ class Position:
 ```python
 class MovementSystem(BaseSystem):
     """Moves entities based on velocity."""
-    
+
     def update(self, world):
         # Query entities with position + velocity
         entities = world.registry.query_by_component("position", "velocity")
-        
+
         for entity in entities.values():
             # Update position based on velocity
             entity.position.prev_x = entity.position.x
@@ -181,10 +181,10 @@ Systems in `src/ecs/systems/` process entities:
 ```python
 class InputSystem(BaseSystem):
     """Converts input into component changes."""
-    
+
     # Reads: pygame events
     # Writes: Velocity, GameState
-    
+
     # Example: right arrow
     if key == K_RIGHT and velocity.dx != -1:
         velocity.dx = 1
@@ -395,7 +395,7 @@ class AppleConfig:
 
 ```python
 # src/ecs/prefabs/apple.py
-def create_apple(world: World, x: int, y: int, grid_size: int, 
+def create_apple(world: World, x: int, y: int, grid_size: int,
                  color=None, points=10, growth=1) -> int:
     """Creates apple at position (x, y) with configured components."""
     apple = Apple(
@@ -424,17 +424,17 @@ class AppleSpawnSystem(BaseSystem):
     def update(self, world: World) -> None:
         # 1. How many do we want?
         desired_count = self._get_desired_apple_count(world)
-        
+
         # 2. How many do we have?
         current_apples = world.registry.query_by_type(EntityType.APPLE)
         current_count = len(current_apples)
-        
+
         # 3. Spawn difference
         for _ in range(desired_count - current_count):
             position = self._find_valid_position(world)
             if position:
                 create_apple(world, x=position[0], y=position[1], ...)
-    
+
     def _find_valid_position(self, world):
         """Finds position that doesn't collide with anything."""
         occupied = self._get_occupied_positions(world)
@@ -488,10 +488,10 @@ def test_spawn_maintains_apple_count():
     # Setup: want 3 apples
     config = Entity(apple_config=AppleConfig(desired_count=3))
     world.registry.add(config)
-    
+
     # Execute system
     system.update(world)
-    
+
     # Verify: has 3 apples?
     assert len(world.registry.query_by_type(EntityType.APPLE)) == 3
 
@@ -618,16 +618,16 @@ snake.velocity.dx = 1
 ```python
 class CollisionSystem(BaseSystem):
     """Detects snake vs apple/obstacle/wall collisions."""
-    
+
     def update(self, world):
         # Get snake
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         if not snakes:
             return
-        
+
         snake_id, snake = next(iter(snakes.items()))
         head_pos = (snake.position.x, snake.position.y)
-        
+
         # Check collision with apples
         apples = world.registry.query_by_type(EntityType.APPLE)
         for apple_id, apple in apples.items():
@@ -636,7 +636,7 @@ class CollisionSystem(BaseSystem):
                 # Collision! Grow snake and remove apple
                 snake.body.size += 1
                 world.registry.remove(apple_id)
-                
+
                 # Update score
                 score_entities = world.registry.query_by_component("score")
                 if score_entities:
@@ -655,23 +655,23 @@ def test_movement_system_moves_entity():
     # Setup
     board = Board(width=20, height=20, cell_size=20)
     world = World(board)
-    
+
     # Create test entity
     entity = Entity(
         position=Position(x=10, y=10),
         velocity=Velocity(dx=1, dy=0, speed=10.0)
     )
     entity_id = world.registry.add(entity)
-    
+
     # Create system
     system = MovementSystem()
-    
+
     # Simulate enough time to move
     world.dt_ms = 100  # 100ms
-    
+
     # Execute
     system.update(world)
-    
+
     # Verify
     entity = world.registry.get(entity_id)
     assert entity.position.x == 11
@@ -686,30 +686,30 @@ def test_snake_eats_apple():
     # Setup
     board = Board(width=20, height=20, cell_size=20)
     world = World(board)
-    
+
     # Create snake and apple at same position
     snake_id = create_snake(world, grid_size=20)
     snake = world.registry.get(snake_id)
     snake.position.x = 10
     snake.position.y = 10
-    
+
     apple_id = create_apple(world, grid_size=20)
     apple = world.registry.get(apple_id)
     apple.position.x = 10
     apple.position.y = 10
-    
+
     # Create score
     score_entity = Entity(score=Score(current=0))
     world.registry.add(score_entity)
-    
+
     # Execute collision system
     collision_system = CollisionSystem(settings=None, audio_service=None)
     collision_system.update(world)
-    
+
     # Verify
     assert snake.body.size == 2  # grew
     assert world.registry.get(apple_id) is None  # apple removed
-    
+
     score_entities = world.registry.query_by_component("score")
     score_entity = next(iter(score_entities.values()))
     assert score_entity.score.current == 10
@@ -751,4 +751,3 @@ pytest tests/ecs/test_movement_system.py  # specific test
 - `docs/CONTRIBUTING.md` - contribution guide
 - `docs/manual.md` - user manual
 - `.cursor/rules/` - detailed ECS rules
-

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -204,23 +204,6 @@ class ECSGameApp:
                 random_seed=None,  # use true randomness
             )
 
-    def _calculate_obstacle_count(self) -> int:
-        """Calculate number of obstacles based on difficulty setting."""
-        difficulty = self.settings.get("obstacle_difficulty")
-
-        # difficulty percentages
-        percentages = {
-            "None": 0.0,
-            "Easy": 0.04,
-            "Medium": 0.06,
-            "Hard": 0.10,
-            "Impossible": 0.15,
-        }
-
-        percentage = percentages.get(difficulty, 0.0)
-        total_cells = self.world.board.width * self.world.board.height
-        return int(total_cells * percentage)
-
     def run(self) -> None:
         """Run the main game loop."""
         if not self.scene_manager:

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -195,11 +195,14 @@ class ECSGameApp:
 
         # create obstacles based on difficulty
         difficulty = self.settings.get("obstacle_difficulty")
+        # define dynamic obstacle according to settings
+        dynamic_spawn = self.settings.get("dynamic_spawn_obstacles")
 
         if difficulty and difficulty != "None":
             _ = create_obstacles(
                 world=self.world,
                 difficulty=difficulty,
+                dynamic_spawn=dynamic_spawn,
                 grid_size=grid_size,
                 random_seed=None,  # use true randomness
             )

--- a/src/ecs/prefabs/obstacle_field.py
+++ b/src/ecs/prefabs/obstacle_field.py
@@ -31,7 +31,17 @@ from core.types.color import Color
 from game import constants
 
 
-DifficultyLevel = Literal["None", "Easy", "Medium", "Hard", "Impossible"]
+DifficultyLevel = Literal[
+    "None",
+    "Easy",
+    "Medium",
+    "Hard",
+    "Impossible",
+    "Dynamic Spawn Easy",
+    "Dynamic Spawn Medium",
+    "Dynamic Spawn Hard",
+    "Dynamic Spawn Impossible",
+]
 
 
 def create_obstacles(
@@ -42,12 +52,9 @@ def create_obstacles(
 ) -> list[int]:
     """Create obstacle entities based on difficulty level.
 
-    Creates obstacles that fill a percentage of the board based on difficulty:
-    - None: 0%
-    - Easy: 4%
-    - Medium: 6%
-    - Hard: 10%
-    - Impossible: 15%
+    Creates obstacles that fill a percentage of the board based on difficulty.
+    Difficulties obstacles percentages are defined as DIFFICULTY_PERCENTAGES in
+    constants.py.
 
     Args:
         world: ECS world to create entities in

--- a/src/ecs/prefabs/obstacle_field.py
+++ b/src/ecs/prefabs/obstacle_field.py
@@ -37,16 +37,13 @@ DifficultyLevel = Literal[
     "Medium",
     "Hard",
     "Impossible",
-    "Dynamic Spawn Easy",
-    "Dynamic Spawn Medium",
-    "Dynamic Spawn Hard",
-    "Dynamic Spawn Impossible",
 ]
 
 
 def create_obstacles(
     world: World,
     difficulty: DifficultyLevel,
+    dynamic_spawn: bool,
     grid_size: int,
     random_seed: Optional[int] = None,
 ) -> list[int]:
@@ -59,6 +56,7 @@ def create_obstacles(
     Args:
         world: ECS world to create entities in
         difficulty: Difficulty level determining number of obstacles
+        dynamic_spawn: Whether to use dynamic spawn mode for obstacles
         grid_size: Size of each grid cell in pixels
         random_seed: Optional seed for deterministic obstacle placement (testing)
 
@@ -66,7 +64,7 @@ def create_obstacles(
         list[int]: List of entity IDs for created obstacles
 
     Example:
-        >>> obstacle_ids = create_obstacles(world, "Medium", grid_size=20)
+        >>> obstacle_ids = create_obstacles(world, "Medium", False, grid_size=20)
         >>> len(obstacle_ids)  # 6% of total cells
         30
     """
@@ -84,7 +82,9 @@ def create_obstacles(
     total_cells = grid_width_tiles * grid_height_tiles
 
     # calculate number of obstacles based on difficulty
-    num_obstacles = _calculate_obstacles_from_difficulty(difficulty, total_cells)
+    num_obstacles = _calculate_obstacles_from_difficulty(
+        difficulty, dynamic_spawn, total_cells
+    )
 
     if num_obstacles == 0:
         return []
@@ -128,18 +128,25 @@ def create_obstacles(
 
 def _calculate_obstacles_from_difficulty(
     difficulty: DifficultyLevel,
+    dynamic_spawn: bool,
     total_cells: int,
 ) -> int:
     """Calculate number of obstacles based on difficulty and total cells.
 
     Args:
         difficulty: Difficulty level
+        dynamic_spawn: Whether dynamic spawn mode is enabled
         total_cells: Total number of cells in the grid
 
     Returns:
         int: Number of obstacles to create
     """
     percentage = constants.DIFFICULTY_PERCENTAGES.get(difficulty, 0.0)
+
+    if dynamic_spawn:
+        # In dynamic spawn mode, use initial coefficient to reduce the number of obstacles
+        percentage *= constants.DYNAMIC_SPAWN_OBSTACLES_INITIAL_COEFFICIENT
+
     return int(total_cells * percentage)
 
 

--- a/src/game/constants.py
+++ b/src/game/constants.py
@@ -32,10 +32,12 @@ DIFFICULTY_PERCENTAGES = {
     "Dynamic Spawn Hard": 0.06,  # Dynamic difficulties require fewer obstacles at start
     "Dynamic Spawn Impossible": 0.10,  # Dynamic difficulties require fewer obstacles at start
 }
-
-# Percentage of blocks that can be occupied by obstacles in dynamic difficulty modes
-# When staturation is reached, no new obstacles will spawn
-DYNAMIC_OBSTACLES_SATURATION_PERCENTAGE = 0.25
+"""
+Coefficient applied to the difficulty obstacle percentages to calculate
+the maximum number of obstacles in dynamic spawn modes, defining a saturation point.
+The value is chosen so that, at maximum difficulty, the board can reach up to 33.0%.
+"""
+DYNAMIC_SPAWN_OBSTACLES_SATURATION_COEFFICIENT = 3.3
 
 # Color palettes for snake customization
 SNAKE_COLOR_PALETTES = [

--- a/src/game/constants.py
+++ b/src/game/constants.py
@@ -27,7 +27,15 @@ DIFFICULTY_PERCENTAGES = {
     "Medium": 0.06,
     "Hard": 0.10,
     "Impossible": 0.15,
+    "Dynamic Spawn Easy": 0.02,  # Dynamic difficulties require fewer obstacles at start
+    "Dynamic Spawn Medium": 0.04,  # Dynamic difficulties require fewer obstacles at start
+    "Dynamic Spawn Hard": 0.06,  # Dynamic difficulties require fewer obstacles at start
+    "Dynamic Spawn Impossible": 0.10,  # Dynamic difficulties require fewer obstacles at start
 }
+
+# Percentage of blocks that can be occupied by obstacles in dynamic difficulty modes
+# When staturation is reached, no new obstacles will spawn
+DYNAMIC_OBSTACLES_SATURATION_PERCENTAGE = 0.25
 
 # Color palettes for snake customization
 SNAKE_COLOR_PALETTES = [

--- a/src/game/constants.py
+++ b/src/game/constants.py
@@ -27,10 +27,6 @@ DIFFICULTY_PERCENTAGES = {
     "Medium": 0.06,
     "Hard": 0.10,
     "Impossible": 0.15,
-    "Dynamic Spawn Easy": 0.02,  # Dynamic difficulties require fewer obstacles at start
-    "Dynamic Spawn Medium": 0.04,  # Dynamic difficulties require fewer obstacles at start
-    "Dynamic Spawn Hard": 0.06,  # Dynamic difficulties require fewer obstacles at start
-    "Dynamic Spawn Impossible": 0.10,  # Dynamic difficulties require fewer obstacles at start
 }
 """
 Coefficient applied to the difficulty obstacle percentages to calculate
@@ -38,6 +34,13 @@ the maximum number of obstacles in dynamic spawn modes, defining a saturation po
 The value is chosen so that, at maximum difficulty, the board can reach up to 33.0%.
 """
 DYNAMIC_SPAWN_OBSTACLES_SATURATION_COEFFICIENT = 3.3
+
+"""
+Coefficient applied to the difficulty obstacle percentages to calculate
+the initial number of obstacles in dynamic spawn modes. The value is chosen
+so that the initial number is 3/4 of the initial value in static modes.
+"""
+DYNAMIC_SPAWN_OBSTACLES_INITIAL_COEFFICIENT = 0.75
 
 # Color palettes for snake customization
 SNAKE_COLOR_PALETTES = [

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -258,12 +258,14 @@ class GameInitializer:
             grid_size: Size of grid cells in pixels
         """
         difficulty = self._settings.get("obstacle_difficulty")
+        dynamic_spawn = self._settings.get("dynamic_spawn_obstacles")
         if difficulty and difficulty != "None":
             from ecs.prefabs.obstacle_field import create_obstacles
 
             _ = create_obstacles(
                 world=world,
                 difficulty=difficulty,
+                dynamic_spawn=dynamic_spawn,
                 grid_size=grid_size,
                 random_seed=None,  # use true randomness
             )

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -75,7 +75,17 @@ class GameSettings:
             "key": "obstacle_difficulty",
             "label": "Obstacles",
             "type": "select",
-            "options": ["None", "Easy", "Medium", "Hard", "Impossible"],
+            "options": [
+                "None",
+                "Easy",
+                "Medium",
+                "Hard",
+                "Impossible",
+                "Dynamic Spawn Easy",
+                "Dynamic Spawn Medium",
+                "Dynamic Spawn Hard",
+                "Dynamic Spawn Impossible",
+            ],
             "requires_reset": True,
         },
         {
@@ -153,6 +163,7 @@ class GameSettings:
             return
         else:
             with open(os.path.join(self.data_dir, "settings.json"), "r") as f:
+                print(f"PATH {self.data_dir}")
                 self.settings = json.load(f)
                 print("Settings loaded from file.")
 

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -151,6 +151,17 @@ class GameSettings:
             "last_step_time": 0,
         }
 
+    def _merge_missing_defaults(self) -> None:
+        """Add any missing default keys (for forward compatibility)."""
+        added = False
+        for k, v in self.DEFAULT_SETTINGS.items():
+            if k not in self.settings:
+                self.settings[k] = v
+                added = True
+        if added:
+            # Persist newly added keys so next run is clean
+            self.save_settings()
+
     def load_settings(self) -> None:
         """Load settings from the user data directory, or initialize as default."""
 
@@ -169,6 +180,8 @@ class GameSettings:
                 print(f"PATH {self.data_dir}")
                 self.settings = json.load(f)
                 print("Settings loaded from file.")
+            # merge in missing keys introduced after file creation
+            self._merge_missing_defaults()
 
     def save_settings(self) -> None:
         """Save current settings to the user data directory."""
@@ -352,6 +365,9 @@ class GameSettings:
         kind = field["type"]
 
         if kind == "bool":
+            if key not in self.settings:
+                # Fallback: initialize from defaults if missing
+                self.settings[key] = self.DEFAULT_SETTINGS.get(key, False)
             self.settings[key] = not self.settings[key]
             return
 

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -38,6 +38,7 @@ class GameSettings:
         "number_of_apples": 1,
         "background_music": True,
         "sound_effects": True,  # Controls all sound effects (eat, death, etc.)
+        "dynamic_spawn_obstacles": False,
         "electric_walls": True,
         "snake_color_palette": "Classic Green",  # New setting
     }
@@ -81,10 +82,6 @@ class GameSettings:
                 "Medium",
                 "Hard",
                 "Impossible",
-                "Dynamic Spawn Easy",
-                "Dynamic Spawn Medium",
-                "Dynamic Spawn Hard",
-                "Dynamic Spawn Impossible",
             ],
             "requires_reset": True,
         },
@@ -108,6 +105,12 @@ class GameSettings:
             "label": "Sound Effects",
             "type": "bool",
             "requires_reset": False,
+        },
+        {
+            "key": "dynamic_spawn_obstacles",
+            "label": "Dynamic Spawn Obstacles",
+            "type": "bool",
+            "requires_reset": True,
         },
         {
             "key": "electric_walls",


### PR DESCRIPTION
Adding Dynamic Spawn Mode to the game configurations as a mode that can be enabled or disabled in the main settings menu. The spawn mode is designed to work as a variation of the difficulty: the maximum number of obstacles spawned is computed as a function of the number of obstacles defined by the selected difficulty level.

The dynamic spawn mode information can be retrieved through the GameSettings class. Two constants were also added to the system to represent an obstacle saturation point and an initial-obstacle reduction factor, ensuring that the overall difficulty remains stable as new obstacles are generated.

This change represents the #347 sub-issue and #327.