### PR TITLE
feat: add speed increase rate option to settings menu

### DIFF
--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -311,7 +311,18 @@ class CollisionSystem(BaseSystem):
                             if self._settings
                             else 20.0
                         )
-                        new_speed = min(current_speed * 1.1, max_speed)
+                        speed_increase_rate = (
+                            self._settings.get("speed_increase_rate")
+                            if self._settings
+                            else "10%"
+                        )
+                        # Convert percentage string to multiplier (5% -> 1.05, 10% -> 1.10)
+                        if speed_increase_rate == "5%":
+                            multiplier = 1.05
+                        else:  # default to 10%
+                            multiplier = 1.10
+                        new_speed = min(current_speed * multiplier, max_speed)
+
                         snake.velocity.speed = new_speed
 
                     # remove eaten apple

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -41,6 +41,7 @@ class GameSettings:
         "dynamic_spawn_obstacles": False,
         "electric_walls": True,
         "snake_color_palette": "Classic Green",  # New setting
+        "speed_increase_rate": "10%",  # Speed increase per apple: 5% or 10%
     }
 
     # Declarative menu field definitions
@@ -71,6 +72,16 @@ class GameSettings:
             "max": 60.0,
             "step": 1.0,
             "requires_reset": True,
+        },
+        {
+            "key": "speed_increase_rate",
+            "label": "Speed increase per apple",
+            "type": "select",
+            "options": [
+                "5%",
+                "10%",
+            ],
+            "requires_reset": False,
         },
         {
             "key": "obstacle_difficulty",


### PR DESCRIPTION
Solving Issue #362. As the 10% increase in speed could be too much, I decided to add an option to only increase 5%.