### PR TITLE
feat: Add head-tail-swap color changing

### DIFF
--- a/src/ecs/components/snake_body.py
+++ b/src/ecs/components/snake_body.py
@@ -36,3 +36,5 @@ class SnakeBody:
     segments: list[Position] = field(default_factory=list)
     size: int = 1  # Guards the size of the snake
     alive: bool = True
+    is_color_swapped: bool = False
+    

--- a/src/ecs/components/snake_body.py
+++ b/src/ecs/components/snake_body.py
@@ -37,4 +37,3 @@ class SnakeBody:
     size: int = 1  # Guards the size of the snake
     alive: bool = True
     is_color_swapped: bool = False
-    

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -291,6 +291,7 @@ class CollisionSystem(BaseSystem):
                     # grow snake
                     if hasattr(snake, "body"):
                         snake.body.size += 1
+                        snake.body.is_color_swapped = not snake.body.is_color_swapped
 
                     # increment score
                     score_entities = world.registry.query_by_component("score")

--- a/src/ecs/systems/snake_render.py
+++ b/src/ecs/systems/snake_render.py
@@ -114,7 +114,6 @@ class SnakeRenderSystem(BaseSystem):
         if hasattr(body, "is_color_swapped") and body.is_color_swapped:
             head_color, tail_color = tail_color, head_color
 
-
         # Draw tail segments with interpolation
         self._draw_snake_tail(
             body,

--- a/src/ecs/systems/snake_render.py
+++ b/src/ecs/systems/snake_render.py
@@ -110,6 +110,11 @@ class SnakeRenderSystem(BaseSystem):
             head_color = Color.from_hex(constants.HEAD_COLOR).to_tuple()
             tail_color = Color.from_hex(constants.TAIL_COLOR).to_tuple()
 
+        # This is for swapping the head and tail (just changing the colors)
+        if hasattr(body, "is_color_swapped") and body.is_color_swapped:
+            head_color, tail_color = tail_color, head_color
+
+
         # Draw tail segments with interpolation
         self._draw_snake_tail(
             body,


### PR DESCRIPTION
This PR introduces the foundational logic for the **"Head-Tail Swap" game mode**. It implements the state toggle when the snake consumes an apple, enabling the visual inversion of the snake's colors.

Issue #367 

**Changes:**

- Added is_color_swapped flag to SnakeBody component.
- Updated CollisionSystem to toggle this flag upon apple consumption.
- Implemented basic color swapping rendering **(currently applies to the entire tail).**

**Future Improvements:**
- Refine SnakeRenderSystem to swap colors only for the last segment (tip) of the tail, rather than the entire body.
- Adjust the snake movement when swapping the head and tail.
- Integrate the feature into the Main Menu (Game Mode selection).

**Task List:**
[x] Update the head and tail colors to simulate the swapping.

[Screencast from 2025-11-18 11-20-11.webm](https://github.com/user-attachments/assets/6b0625d4-86fd-4719-a335-4e261b456221)
