### PR TITLE
Creating a safe zone so obstacles wont grow right next to the snake in the beggining

### DIFF
--- a/src/ecs/prefabs/obstacle_field.py
+++ b/src/ecs/prefabs/obstacle_field.py
@@ -92,6 +92,9 @@ def create_obstacles(
     # get all occupied cells (snake, apples, etc)
     occupied_cells = _get_occupied_cells(world)
 
+    # Add safe zone cells to occupied cells to prevent spawning there
+    occupied_cells.update(_get_safe_zone_cells(world))
+
     # get all available cells for obstacle placement
     available_cells = []
     for tile_x in range(grid_width_tiles):
@@ -179,3 +182,35 @@ def _get_occupied_cells(world: World) -> set[tuple[int, int]]:
                 occupied.add((segment.x, segment.y))
 
     return occupied
+
+
+def _get_safe_zone_cells(world: World) -> set[tuple[int, int]]:
+    """Get set of safe zone cells where obstacles should not spawn.
+
+    Includes 3 cells in front of the snake's movement direction.
+
+    Args:
+        world: ECS world to query
+
+    Returns:
+        set[tuple[int, int]]: Set of (x, y) tuples representing safe cells
+    """
+    safe_cells = set()
+    registry = world.registry
+    from ecs.entities.entity import EntityType
+
+    snakes = registry.query_by_type(EntityType.SNAKE)
+    for _, snake in snakes.items():
+        if hasattr(snake, "position") and hasattr(snake, "velocity"):
+            head_x, head_y = snake.position.x, snake.position.y
+            dx, dy = snake.velocity.dx, snake.velocity.dy
+
+            # Block 3 cells in front of the snake
+            # If velocity is 0 (unlikely for snake), we don't block anything extra
+            if dx != 0 or dy != 0:
+                for i in range(1, 4):
+                    safe_x = head_x + int(dx * i)
+                    safe_y = head_y + int(dy * i)
+                    safe_cells.add((safe_x, safe_y))
+
+    return safe_cells

--- a/src/ecs/prefabs/obstacle_field.py
+++ b/src/ecs/prefabs/obstacle_field.py
@@ -208,9 +208,12 @@ def _get_safe_zone_cells(world: World) -> set[tuple[int, int]]:
             # Block 3 cells in front of the snake
             # If velocity is 0 (unlikely for snake), we don't block anything extra
             if dx != 0 or dy != 0:
+                board = world.board
                 for i in range(1, 4):
-                    safe_x = head_x + int(dx * i)
-                    safe_y = head_y + int(dy * i)
-                    safe_cells.add((safe_x, safe_y))
+                    safe_x = head_x + dx * i
+                    safe_y = head_y + dy * i
+                    # Only add cells within grid boundaries
+                    if 0 <= safe_x < board.width and 0 <= safe_y < board.height:
+                        safe_cells.add((safe_x, safe_y))
 
     return safe_cells

--- a/tests/ecs/test_obstacle_safe_zone.py
+++ b/tests/ecs/test_obstacle_safe_zone.py
@@ -1,0 +1,70 @@
+from ecs.world import World
+from ecs.board import Board
+from ecs.prefabs.snake import create_snake
+from ecs.prefabs.obstacle_field import create_obstacles, _get_safe_zone_cells
+
+
+def test_obstacle_safe_zone_logic():
+    """Test that _get_safe_zone_cells returns the correct cells."""
+    board = Board(width=10, height=10, cell_size=1)
+    world = World(board)
+
+    # Create snake at (5, 5) moving right (dx=1, dy=0)
+    snake_id = create_snake(world, grid_size=1)
+    snake = world.registry.get(snake_id)
+    snake.position.x = 5
+    snake.position.y = 5
+    snake.velocity.dx = 1
+    snake.velocity.dy = 0
+
+    safe_cells = _get_safe_zone_cells(world)
+    expected_safe = {(6, 5), (7, 5), (8, 5)}
+
+    assert expected_safe.issubset(safe_cells)
+
+
+def test_obstacle_safe_zone_boundary_check():
+    """Test that _get_safe_zone_cells respects board boundaries."""
+    board = Board(width=10, height=10, cell_size=1)
+    world = World(board)
+
+    # Create snake at (9, 5) moving right (dx=1, dy=0)
+    # This is at the edge, so safe zone would be (10, 5), (11, 5), (12, 5) which are out of bounds
+    snake_id = create_snake(world, grid_size=1)
+    snake = world.registry.get(snake_id)
+    snake.position.x = 9
+    snake.position.y = 5
+    snake.velocity.dx = 1
+    snake.velocity.dy = 0
+
+    safe_cells = _get_safe_zone_cells(world)
+
+    # Should be empty as all potential safe cells are out of bounds
+    assert len(safe_cells) == 0
+
+
+def test_create_obstacles_respects_safe_zone():
+    """Test that create_obstacles does not spawn obstacles in the safe zone."""
+    board = Board(width=10, height=10, cell_size=1)
+    world = World(board)
+
+    # Create snake at (5, 5) moving right (dx=1, dy=0)
+    snake_id = create_snake(world, grid_size=1)
+    snake = world.registry.get(snake_id)
+    snake.position.x = 5
+    snake.position.y = 5
+    snake.velocity.dx = 1
+    snake.velocity.dy = 0
+
+    # Generate obstacles
+    obstacle_ids = create_obstacles(
+        world, "Impossible", False, grid_size=1, random_seed=42
+    )
+
+    obstacles = [world.registry.get(oid) for oid in obstacle_ids]
+
+    safe_zone = {(6, 5), (7, 5), (8, 5)}
+
+    for obs in obstacles:
+        pos = (obs.position.x, obs.position.y)
+        assert pos not in safe_zone, f"Obstacle spawned in safe zone at {pos}"


### PR DESCRIPTION
**Description**
This PR fixes an issue where obstacles could spawn directly in front of the snake's head when the game starts, causing unavoidable collisions.

**Changes Made**
- Modified `src/ecs/prefabs/obstacle_field.py`.
- Added `_get_safe_zone_cells` helper function to calculate the 3 cells directly in front of the snake based on its velocity.
- Updated `create_obstacles` to include these safe zone cells in the `occupied_cells` set, ensuring obstacles are not generated there.

**Related Issue**
Closes #391 