### PR TITLE
[FEAT] Reorganize settings menu

### DIFF
--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -174,15 +174,15 @@ class OverlayRenderSystem(BaseSystem):
         padding_y = int(surface_height * 0.20)
         left_margin = int(surface_width * 0.15)
         category_indent = int(surface_width * 0.05)
-        
+
         # Calculate scroll offset
         item_height_avg = row_h
         scroll_offset = max(0, (selected_index - 3) * item_height_avg)
-        
+
         # Get in-game adjustable settings
         menu_fields = self._settings.get_in_game_menu_fields()
         return_to_menu_index = len(menu_fields)
-        
+
         # Calculate available height for content
         content_start_y = padding_y
         content_end_y = int(surface_height * 0.88)
@@ -199,17 +199,17 @@ class OverlayRenderSystem(BaseSystem):
 
         current_y = padding_y - scroll_offset
         current_category = None
-        
+
         # Draw settings grouped by category
         for field_i, f in enumerate(menu_fields):
             # Draw category header if this is a new category
             if f.get("category") != current_category:
                 current_category = f.get("category", "Other")
-                
+
                 # Add spacing before category (except first)
                 if field_i > 0:
                     current_y += int(surface_height * 0.03)
-                
+
                 # Draw category header only if visible
                 if content_start_y - category_h <= current_y <= content_end_y:
                     category_text = category_font.render(
@@ -221,43 +221,47 @@ class OverlayRenderSystem(BaseSystem):
                     category_rect.left = left_margin - category_indent
                     category_rect.top = current_y
                     self._renderer.blit(category_text, category_rect)
-                
+
                 current_y += category_h
-            
+
             # Draw setting field only if visible
             if content_start_y - row_h <= current_y <= content_end_y:
                 val = self._settings.get(f["key"])
-                
+
                 # Calculate current grid size for display
                 current_grid_size = 20
                 if self._config:
                     desired_cells = max(10, int(self._settings.get("cells_per_side")))
-                    current_grid_size = self._config.get_optimal_grid_size(desired_cells)
-                
+                    current_grid_size = self._config.get_optimal_grid_size(
+                        desired_cells
+                    )
+
                 formatted_val = self._settings.format_setting_value(
                     f,
                     val,
                     surface_width,
                     current_grid_size,
                 )
-                
+
                 # Highlight selected item
                 text_color = (
                     Color.from_hex(constants.SCORE_COLOR).to_tuple()
                     if field_i == selected_index
                     else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
                 )
-                text = item_font.render(f"{f['label']}: {formatted_val}", True, text_color)
+                text = item_font.render(
+                    f"{f['label']}: {formatted_val}", True, text_color
+                )
                 rect = text.get_rect()
                 rect.left = left_margin
                 rect.top = current_y
                 self._renderer.blit(text, rect)
-            
+
             current_y += row_h
 
         # Draw "Return to Menu" option
         current_y += int(surface_height * 0.04)
-        
+
         # Only draw if visible
         if content_start_y - row_h <= current_y <= content_end_y:
             text_color = (
@@ -265,7 +269,9 @@ class OverlayRenderSystem(BaseSystem):
                 if selected_index == return_to_menu_index
                 else (200, 100, 100)
             )
-            return_text = item_font.render("──  Return to Main Menu  ──", True, text_color)
+            return_text = item_font.render(
+                "──  Return to Main Menu  ──", True, text_color
+            )
             rect = return_text.get_rect()
             rect.left = left_margin - category_indent
             rect.top = current_y

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -165,71 +165,110 @@ class OverlayRenderSystem(BaseSystem):
     def _draw_settings_items(
         self, surface_width: int, surface_height: int, selected_index: int
     ) -> None:
-        """Draw individual settings items."""
+        """Draw individual settings items with categorized layout."""
         font_path = "assets/font/GetVoIP-Grotesque.ttf"
 
-        # spacing and scroll parameters
-        row_h = int(surface_height * 0.06)
-        visible_rows = int(surface_height * 0.70 // row_h)
-        top_index = max(0, selected_index - visible_rows + 3)
-        padding_y = int(surface_height * 0.22)
-
-        # get in-game adjustable settings
+        # Layout parameters
+        row_h = int(surface_height * 0.055)
+        category_h = int(surface_height * 0.07)
+        padding_y = int(surface_height * 0.20)
+        left_margin = int(surface_width * 0.15)
+        category_indent = int(surface_width * 0.05)
+        
+        # Calculate scroll offset
+        item_height_avg = row_h
+        scroll_offset = max(0, (selected_index - 3) * item_height_avg)
+        
+        # Get in-game adjustable settings
         menu_fields = self._settings.get_in_game_menu_fields()
         return_to_menu_index = len(menu_fields)
+        
+        # Calculate available height for content
+        content_start_y = padding_y
+        content_end_y = int(surface_height * 0.88)
 
-        item_font_size = int(surface_width / 30)
+        # Fonts
+        item_font_size = int(surface_width / 32)
+        category_font_size = int(surface_width / 32)
         try:
             item_font = pygame.font.Font(font_path, item_font_size)
+            category_font = pygame.font.Font(font_path, category_font_size)
         except Exception:
             item_font = pygame.font.Font(None, item_font_size)
+            category_font = pygame.font.Font(None, category_font_size)
 
-        # draw settings items
-        for draw_i, field_i in enumerate(range(top_index, len(menu_fields))):
-            if draw_i >= visible_rows:
-                break
-            f = menu_fields[field_i]
-            val = self._settings.get(f["key"])
+        current_y = padding_y - scroll_offset
+        current_category = None
+        
+        # Draw settings grouped by category
+        for field_i, f in enumerate(menu_fields):
+            # Draw category header if this is a new category
+            if f.get("category") != current_category:
+                current_category = f.get("category", "Other")
+                
+                # Add spacing before category (except first)
+                if field_i > 0:
+                    current_y += int(surface_height * 0.03)
+                
+                # Draw category header only if visible
+                if content_start_y - category_h <= current_y <= content_end_y:
+                    category_text = category_font.render(
+                        f"─── {current_category} ───",
+                        True,
+                        (180, 180, 180),
+                    )
+                    category_rect = category_text.get_rect()
+                    category_rect.left = left_margin - category_indent
+                    category_rect.top = current_y
+                    self._renderer.blit(category_text, category_rect)
+                
+                current_y += category_h
+            
+            # Draw setting field only if visible
+            if content_start_y - row_h <= current_y <= content_end_y:
+                val = self._settings.get(f["key"])
+                
+                # Calculate current grid size for display
+                current_grid_size = 20
+                if self._config:
+                    desired_cells = max(10, int(self._settings.get("cells_per_side")))
+                    current_grid_size = self._config.get_optimal_grid_size(desired_cells)
+                
+                formatted_val = self._settings.format_setting_value(
+                    f,
+                    val,
+                    surface_width,
+                    current_grid_size,
+                )
+                
+                # Highlight selected item
+                text_color = (
+                    Color.from_hex(constants.SCORE_COLOR).to_tuple()
+                    if field_i == selected_index
+                    else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
+                )
+                text = item_font.render(f"{f['label']}: {formatted_val}", True, text_color)
+                rect = text.get_rect()
+                rect.left = left_margin
+                rect.top = current_y
+                self._renderer.blit(text, rect)
+            
+            current_y += row_h
 
-            # calculate current grid size for display
-            current_grid_size = 20  # default fallback
-            if self._config:
-                desired_cells = max(10, int(self._settings.get("cells_per_side")))
-                current_grid_size = self._config.get_optimal_grid_size(desired_cells)
-
-            formatted_val = self._settings.format_setting_value(
-                f,
-                val,
-                surface_width,
-                current_grid_size,
-            )
-
-            # render text with highlighting for selected item
-            text_color = (
-                Color.from_hex(constants.SCORE_COLOR).to_tuple()
-                if field_i == selected_index
-                else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
-            )
-            text = item_font.render(f"{f['label']}: {formatted_val}", True, text_color)
-            rect = text.get_rect()
-            rect.left = int(surface_width * 0.10)
-            rect.top = padding_y + draw_i * row_h
-            self._renderer.blit(text, rect)
-
-        # draw "Return to Menu" option
-        return_draw_i = len(menu_fields) - top_index
-        if 0 <= return_draw_i < visible_rows:
+        # Draw "Return to Menu" option
+        current_y += int(surface_height * 0.04)
+        
+        # Only draw if visible
+        if content_start_y - row_h <= current_y <= content_end_y:
             text_color = (
                 Color.from_hex(constants.SCORE_COLOR).to_tuple()
                 if selected_index == return_to_menu_index
-                else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
+                else (200, 100, 100)
             )
-            separator_top = padding_y + return_draw_i * row_h
-            # add some spacing before the option
-            return_text = item_font.render("Return to Main Menu", True, text_color)
+            return_text = item_font.render("──  Return to Main Menu  ──", True, text_color)
             rect = return_text.get_rect()
-            rect.left = int(surface_width * 0.10)
-            rect.top = separator_top + int(row_h * 0.5)  # add spacing
+            rect.left = left_margin - category_indent
+            rect.top = current_y
             self._renderer.blit(return_text, rect)
 
     def _draw_settings_hint(self, surface_width: int, surface_height: int) -> None:

--- a/src/game/game_modes_registry.py
+++ b/src/game/game_modes_registry.py
@@ -38,7 +38,7 @@ ACTUAL_GAME_MODES = [
     },
 ]
 
-RANDOM_MODE_LABEL = "🎲 Random"
+RANDOM_MODE_LABEL = "Random"
 RANDOM_MODE_INDEX = len(ACTUAL_GAME_MODES)
 
 __all__ = [

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -163,49 +163,49 @@ class GameModesScene(BaseScene):
 
         # Draw title
         title = self._assets.render_custom(
-            "Game Modes", MESSAGE_COLOR, int(self._width / 15)
+            "Game Modes", MESSAGE_COLOR, int(self._width / 12)
         )
-        title_rect = title.get_rect(center=(self._width / 2, self._height / 4))
+        title_rect = title.get_rect(center=(self._width / 2, self._height / 6))
         self._renderer.blit(title, title_rect)
 
-        # Draw menu items
+        # Layout parameters - no scroll needed for few items
+        item_spacing = self._height * 0.10
+        base_y = self._height * 0.35
+
+        # Draw menu items (no scrolling for few items)
         for i, item in enumerate(self._menu_items):
+            item_y = base_y + i * item_spacing
+
             color = SCORE_COLOR if i == self._selected_index else MESSAGE_COLOR
 
             # add arrow indicator if this mode is selected (confirmed)
             display_text = item
-            if i == self._selected_index:
+            if i == get_selected_game_mode():
                 display_text = f">> {item} <<"
 
-            text = self._assets.render_small(display_text, color)
-            rect = text.get_rect(
-                center=(self._width / 2, self._height / 2 + i * (self._height * 0.12))
+            # Use smaller font size
+            text = self._assets.render_custom(
+                display_text, color, int(self._width / 28)
             )
+            rect = text.get_rect(center=(self._width / 2, item_y))
             self._renderer.blit(text, rect)
 
-        # Draw description for selected mode
-        description = self._get_description_for_index(self._selected_index)
-        if description:
-            desc_text = self._assets.render_custom(
-                description, (120, 120, 120), int(self._width / 45)
-            )
-            desc_rect = desc_text.get_rect(
-                center=(
-                    self._width / 2,
-                    self._height / 2
-                    + self._selected_index * (self._height * 0.12)
-                    + self._height * 0.08,
-                )
-            )
-            self._renderer.blit(desc_text, desc_rect)
+            # Draw description for currently navigated mode (closer to the mode name)
+            if i == self._selected_index:
+                description = self._get_description_for_index(i)
+                if description:
+                    desc_y = item_y + self._height * 0.035
+                    desc_text = self._assets.render_custom(
+                        description, (120, 120, 120), int(self._width / 50)
+                    )
+                    desc_rect = desc_text.get_rect(center=(self._width / 2, desc_y))
+                    self._renderer.blit(desc_text, desc_rect)
 
-        # Draw back instruction
+        # Draw back instruction (always at the bottom)
         back_text = self._assets.render_custom(
             "Press ESC to go back", MESSAGE_COLOR, int(self._width / 40)
         )
-        back_rect = back_text.get_rect(
-            center=(self._width / 2, self._height - self._height * 0.1)
-        )
+        back_rect = back_text.get_rect(center=(self._width / 2, self._height * 0.92))
         self._renderer.blit(back_text, back_rect)
 
     def on_enter(self) -> None:

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -180,7 +180,7 @@ class SettingsScene(BaseScene):
         # Calculate available height for content
         content_start_y = padding_y
         content_end_y = int(self._height * 0.88)
-        
+
         # Calculate scroll offset to keep selected item visible
         item_height_avg = row_h
         scroll_offset = max(0, (self._selected_index - 3) * item_height_avg)

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -159,7 +159,7 @@ class SettingsScene(BaseScene):
                 pygame.mixer.pause()
 
     def render(self) -> None:
-        """Render the settings screen."""
+        """Render the settings screen with categorized layout."""
         # Clear screen
         self._renderer.fill(ARENA_COLOR)
 
@@ -170,55 +170,97 @@ class SettingsScene(BaseScene):
         title_rect = title.get_rect(center=(self._width / 2, self._height / 10))
         self._renderer.blit(title, title_rect)
 
-        # Spacing and scroll parameters
-        row_h = int(self._height * 0.06)
-        visible_rows = int(self._height * 0.70 // row_h)
-        top_index = max(0, self._selected_index - visible_rows + 3)
-        padding_y = int(self._height * 0.22)
+        # Layout parameters
+        row_h = int(self._height * 0.055)
+        category_h = int(self._height * 0.07)
+        padding_y = int(self._height * 0.20)
+        left_margin = int(self._width * 0.15)
+        category_indent = int(self._width * 0.05)
 
-        # Draw visible rows
-        for draw_i, field_i in enumerate(
-            range(top_index, len(self._settings.MENU_FIELDS))
-        ):
-            if draw_i >= visible_rows:
-                break
-            f = self._settings.MENU_FIELDS[field_i]
-            val = self._settings.get(f["key"])
+        # Calculate available height for content
+        content_start_y = padding_y
+        content_end_y = int(self._height * 0.88)
+        
+        # Calculate scroll offset to keep selected item visible
+        item_height_avg = row_h
+        scroll_offset = max(0, (self._selected_index - 3) * item_height_avg)
 
-            # Calculate current grid size for display
-            current_grid_size = 20  # default fallback
-            if self._config:
-                desired_cells = max(10, int(self._settings.get("cells_per_side")))
-                current_grid_size = self._config.get_optimal_grid_size(desired_cells)
+        current_y = padding_y - scroll_offset
+        current_category = None
 
-            formatted_val = self._settings.format_setting_value(
-                f,
-                val,
-                self._width,
-                current_grid_size,
-            )
-            text = self._assets.render_custom(
-                f"{f['label']}: {formatted_val}",
-                SCORE_COLOR if field_i == self._selected_index else MESSAGE_COLOR,
-                int(self._width / 30),
-            )
-            rect = text.get_rect()
-            rect.left = int(self._width * 0.10)
-            rect.top = padding_y + draw_i * row_h
-            self._renderer.blit(text, rect)
+        # Draw settings grouped by category
+        for field_i, f in enumerate(self._settings.MENU_FIELDS):
+            # Draw category header if this is a new category
+            if f.get("category") != current_category:
+                current_category = f.get("category", "Other")
+
+                # Add spacing before category (except first)
+                if field_i > 0:
+                    current_y += int(self._height * 0.03)
+
+                # Draw category header only if visible
+                if content_start_y - category_h <= current_y <= content_end_y:
+                    category_text = self._assets.render_custom(
+                        f"─── {current_category} ───",
+                        (180, 180, 180),
+                        int(self._width / 32),
+                    )
+                    category_rect = category_text.get_rect()
+                    category_rect.left = left_margin - category_indent
+                    category_rect.top = current_y
+                    self._renderer.blit(category_text, category_rect)
+
+                current_y += category_h
+
+            # Draw setting field only if visible
+            if content_start_y - row_h <= current_y <= content_end_y:
+                val = self._settings.get(f["key"])
+
+                # Calculate current grid size for display
+                current_grid_size = 20
+                if self._config:
+                    desired_cells = max(10, int(self._settings.get("cells_per_side")))
+                    current_grid_size = self._config.get_optimal_grid_size(
+                        desired_cells
+                    )
+
+                formatted_val = self._settings.format_setting_value(
+                    f,
+                    val,
+                    self._width,
+                    current_grid_size,
+                )
+
+                # Highlight selected item
+                color = (
+                    SCORE_COLOR if field_i == self._selected_index else MESSAGE_COLOR
+                )
+                text = self._assets.render_custom(
+                    f"{f['label']}: {formatted_val}",
+                    color,
+                    int(self._width / 32),
+                )
+                rect = text.get_rect()
+                rect.left = left_margin
+                rect.top = current_y
+                self._renderer.blit(text, rect)
+
+            current_y += row_h
 
         # Draw "Reset to Default" button
+        current_y += int(self._height * 0.04)
         reset_index = len(self._settings.MENU_FIELDS)
-        if reset_index >= top_index and (reset_index - top_index) < visible_rows:
-            draw_pos = reset_index - top_index
+
+        # Only draw if visible
+        if content_start_y - row_h <= current_y <= content_end_y:
             reset_text = self._assets.render_custom(
-                "Reset to Default",
-                SCORE_COLOR if self._selected_index == reset_index else MESSAGE_COLOR,
-                int(self._width / 30),
+                "──  Reset to Default  ──",
+                SCORE_COLOR if self._selected_index == reset_index else (200, 100, 100),
+                int(self._width / 32),
             )
             reset_rect = reset_text.get_rect()
-            reset_rect.left = int(self._width * 0.10)
-            reset_rect.top = padding_y + draw_pos * row_h
+            reset_rect.left = left_margin - category_indent
+            reset_rect.top = current_y
             self._renderer.blit(reset_text, reset_rect)
 
         # Hint footer

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -44,17 +44,24 @@ class GameSettings:
         "speed_increase_rate": "10%",  # Speed increase per apple: 5% or 10%
     }
 
-    # Declarative menu field definitions
+    # Declarative menu field definitions organized by category
     MENU_FIELDS = [
+        # Audio category
         {
-            "key": "cells_per_side",
-            "label": "Cells per side",
-            "type": "int",
-            "min": 10,
-            "max": 60,
-            "step": 1,
-            "requires_reset": True,
+            "key": "background_music",
+            "label": "Background music",
+            "type": "bool",
+            "requires_reset": False,
+            "category": "Audio",
         },
+        {
+            "key": "sound_effects",
+            "label": "Sound effects",
+            "type": "bool",
+            "requires_reset": False,
+            "category": "Audio",
+        },
+        # Gameplay category
         {
             "key": "initial_speed",
             "label": "Initial speed",
@@ -63,6 +70,7 @@ class GameSettings:
             "max": 40.0,
             "step": 0.5,
             "requires_reset": True,
+            "category": "Gameplay",
         },
         {
             "key": "max_speed",
@@ -72,6 +80,7 @@ class GameSettings:
             "max": 60.0,
             "step": 1.0,
             "requires_reset": True,
+            "category": "Gameplay",
         },
         {
             "key": "speed_increase_rate",
@@ -82,6 +91,17 @@ class GameSettings:
                 "10%",
             ],
             "requires_reset": False,
+            "category": "Gameplay",
+        },
+        {
+            "key": "number_of_apples",
+            "label": "Apples",
+            "type": "int",
+            "min": 1,
+            "max": 30,
+            "step": 1,
+            "requires_reset": True,
+            "category": "Gameplay",
         },
         {
             "key": "obstacle_difficulty",
@@ -95,48 +115,45 @@ class GameSettings:
                 "Impossible",
             ],
             "requires_reset": True,
-        },
-        {
-            "key": "number_of_apples",
-            "label": "Apples",
-            "type": "int",
-            "min": 1,
-            "max": 30,
-            "step": 1,
-            "requires_reset": True,
-        },
-        {
-            "key": "background_music",
-            "label": "Background Music",
-            "type": "bool",
-            "requires_reset": False,
-        },
-        {
-            "key": "sound_effects",
-            "label": "Sound Effects",
-            "type": "bool",
-            "requires_reset": False,
+            "category": "Gameplay",
         },
         {
             "key": "dynamic_spawn_obstacles",
-            "label": "Dynamic Spawn Obstacles",
+            "label": "Dynamic spawn obstacles",
             "type": "bool",
             "requires_reset": True,
+            "category": "Gameplay",
         },
         {
             "key": "electric_walls",
             "label": "Electric walls",
             "type": "bool",
             "requires_reset": True,
+            "category": "Gameplay",
+        },
+        # Display category
+        {
+            "key": "cells_per_side",
+            "label": "Board size",
+            "type": "int",
+            "min": 10,
+            "max": 60,
+            "step": 1,
+            "requires_reset": True,
+            "category": "Display",
         },
         {
             "key": "snake_color_palette",
-            "label": "Snake Color",
+            "label": "Snake color",
             "type": "select",
             "options": [palette["name"] for palette in SNAKE_COLOR_PALETTES],
             "requires_reset": False,
+            "category": "Display",
         },
     ]
+
+    # Category order for display
+    CATEGORIES = ["Audio", "Gameplay", "Display"]
 
     # Key repeat settings
     KEY_REPEAT_INITIAL_DELAY = 0.4  # Initial delay before repeat starts (seconds)


### PR DESCRIPTION
## Description
Reorganizes the Settings menu by grouping related options into three categories (Audio, Gameplay, Display) for improved clarity and navigation. Audio settings are now at the top for quick access during gameplay.

## Related Issue
Closes #348

## Changes Made
- Organized settings into categories: **Audio**, **Gameplay**, and **Display**
- Added category headers with visual separators
- Implemented scrolling for comfortable navigation through all settings
- Applied same categorized layout to in-game settings overlay (ESC/M menu)
- Improved game modes menu layout (better spacing, smaller fonts, removed unnecessary scrolling)

## Screenshots
**Main Settings Menu:**
<img width="809" height="820" alt="Screenshot 2025-11-21 at 11 41 21" src="https://github.com/user-attachments/assets/a70b9da8-2cc9-4cec-a964-8d608ec6d21b" />

<img width="832" height="835" alt="Screenshot 2025-11-21 at 11 41 28" src="https://github.com/user-attachments/assets/aa855ad3-4b31-4cb6-8ab4-83e26dfe5521" />


- Categories clearly visible with headers
- Audio at top (Background music, Sound effects)
- Gameplay in middle (Speed, apples, obstacles, etc.)
- Display at bottom (Board size, snake color)
- Reset to Default button at bottom

**In-Game Settings:**
- Same categorization as main menu
- Scrolling enabled for navigation
- Return to Main Menu option at bottom