### PR TITLE
Refactor/399/add scoring helper method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/src/ecs/systems/scoring.py
+++ b/src/ecs/systems/scoring.py
@@ -90,13 +90,10 @@ class ScoringSystem(BaseSystem):
 
     def _get_score_entity(self, world):
         """Return the single score entity, or None if it doesn't exist."""
-        score_entities = world.registry.query_by_component("current")
-
-        if not score_entities:
-            return None
-
-        score_entity_id = list(score_entities.keys())[0]
-        return world.registry.get(score_entity_id)
+        for entity in world.registry.get_all().values():
+            if hasattr(entity, "score"):
+                return entity
+        return None
 
     def on_apple_eaten(self, world: World, points: int) -> None:
         """Handle apple eaten event and update score.
@@ -185,9 +182,7 @@ class ScoringSystem(BaseSystem):
         if score_entity is None:
             return 0
 
-        return score_entity.high_score
-
-
+        return score_entity.score.high_score
 
     def set_high_score(self, world: World, high_score: int) -> None:
         """Set high score explicitly.

--- a/src/ecs/systems/scoring.py
+++ b/src/ecs/systems/scoring.py
@@ -88,6 +88,16 @@ class ScoringSystem(BaseSystem):
         # No periodic behavior needed
         pass
 
+    def _get_score_entity(self, world):
+        """Return the single score entity, or None if it doesn't exist."""
+        score_entities = world.registry.query_by_component("current")
+
+        if not score_entities:
+            return None
+
+        score_entity_id = list(score_entities.keys())[0]
+        return world.registry.get(score_entity_id)
+
     def on_apple_eaten(self, world: World, points: int) -> None:
         """Handle apple eaten event and update score.
 
@@ -95,18 +105,9 @@ class ScoringSystem(BaseSystem):
             world: ECS world
             points: Points to add to score
         """
-        # find score entity (should be singleton)
-        score_entities = world.registry.query_by_component("score")
-
-        if not score_entities:
-            # no score entity exists, cannot update
-            return
-
-        # get first score entity (singleton pattern)
-        score_entity_id = list(score_entities.keys())[0]
-        score_entity = world.registry.get(score_entity_id)
-
-        if not hasattr(score_entity, "score"):
+        # get score entity (singleton pattern)
+        score_entity = self._get_score_entity(world)
+        if score_entity is None:
             return
 
         # update current score
@@ -127,16 +128,9 @@ class ScoringSystem(BaseSystem):
             world: ECS world
             snake_tail_length: Current snake tail length
         """
-        # find score entity
-        score_entities = world.registry.query_by_component("score")
-
-        if not score_entities:
-            return
-
-        score_entity_id = list(score_entities.keys())[0]
-        score_entity = world.registry.get(score_entity_id)
-
-        if not hasattr(score_entity, "score"):
+        # get score entity
+        score_entity = self._get_score_entity(world)
+        if score_entity is None:
             return
 
         # update current score to match snake length
@@ -155,16 +149,9 @@ class ScoringSystem(BaseSystem):
         Args:
             world: ECS world
         """
-        # find score entity
-        score_entities = world.registry.query_by_component("score")
-
-        if not score_entities:
-            return
-
-        score_entity_id = list(score_entities.keys())[0]
-        score_entity = world.registry.get(score_entity_id)
-
-        if not hasattr(score_entity, "score"):
+        # get score entity
+        score_entity = self._get_score_entity(world)
+        if score_entity is None:
             return
 
         # reset current score to 0
@@ -179,18 +166,11 @@ class ScoringSystem(BaseSystem):
         Returns:
             Current score, or 0 if no score entity exists
         """
-        score_entities = world.registry.query_by_component("score")
-
-        if not score_entities:
+        score_entity = self._get_score_entity(world)
+        if score_entity is None:
             return 0
 
-        score_entity_id = list(score_entities.keys())[0]
-        score_entity = world.registry.get(score_entity_id)
-
-        if hasattr(score_entity, "score"):
-            return score_entity.score.current
-
-        return 0
+        return score_entity.score.current
 
     def get_high_score(self, world: World) -> int:
         """Get high score.
@@ -201,18 +181,13 @@ class ScoringSystem(BaseSystem):
         Returns:
             High score, or 0 if no score entity exists
         """
-        score_entities = world.registry.query_by_component("score")
-
-        if not score_entities:
+        score_entity = self._get_score_entity(world)
+        if score_entity is None:
             return 0
 
-        score_entity_id = list(score_entities.keys())[0]
-        score_entity = world.registry.get(score_entity_id)
+        return score_entity.high_score
 
-        if hasattr(score_entity, "score"):
-            return score_entity.score.high_score
 
-        return 0
 
     def set_high_score(self, world: World, high_score: int) -> None:
         """Set high score explicitly.
@@ -223,16 +198,11 @@ class ScoringSystem(BaseSystem):
             world: ECS world
             high_score: High score value to set
         """
-        score_entities = world.registry.query_by_component("score")
-
-        if not score_entities:
+        score_entity = self._get_score_entity(world)
+        if score_entity is None:
             return
 
-        score_entity_id = list(score_entities.keys())[0]
-        score_entity = world.registry.get(score_entity_id)
-
-        if hasattr(score_entity, "score"):
-            score_entity.score.high_score = high_score
+        score_entity.score.high_score = high_score
 
     def save_score_to_scoreboard(self, world: World) -> bool:
         """Save current score to scoreboard.
@@ -273,17 +243,9 @@ class ScoringSystem(BaseSystem):
         Returns:
             Tuple of (current_score, high_score)
         """
-        score_entities = world.registry.query_by_component("score")
-
-        if not score_entities:
+        # get score entity
+        score_entity = self._get_score_entity(world)
+        if score_entity is None:
             return (0, 0)
 
-        score_entity_id = list(score_entities.keys())[0]
-        score_entity = world.registry.get(score_entity_id)
-
-        if hasattr(score_entity, "score"):
-            current = score_entity.score.current
-            high = score_entity.score.high_score
-            return (current, high)
-
-        return (0, 0)
+        return (score_entity.score.current, score_entity.score.high_score)

--- a/tests/ecs/test_scoring_system.py
+++ b/tests/ecs/test_scoring_system.py
@@ -416,3 +416,13 @@ class TestIntegration:
             scoring_system.reset_current_score(world_with_score)
             assert scoring_system.get_current_score(world_with_score) == 0
             assert scoring_system.get_high_score(world_with_score) == 10
+
+        def test_get_scores_returns_correct_tuple(
+            self, world_with_score, scoring_system
+        ):
+            """get_scores returns (current, high)."""
+            scoring_system.on_apple_eaten(world_with_score, points=10)
+            scoring_system.reset_current_score(world_with_score)
+            current, high = scoring_system.get_scores(world_with_score)
+            assert current == 0
+            assert high == 10

--- a/tests/ecs/test_scoring_system.py
+++ b/tests/ecs/test_scoring_system.py
@@ -401,3 +401,11 @@ class TestIntegration:
                 world_with_score, snake_tail_length=5
             )
             assert scoring_system.get_current_score(world_with_score) == 5
+
+        def test_high_score_remains_highest(self, world_with_score, scoring_system):
+            """High score is preserved when score is overwritten."""
+            scoring_system.on_apple_eaten(world_with_score, points=10)
+            scoring_system.update_score_from_snake_length(
+                world_with_score, snake_tail_length=5
+            )
+            assert scoring_system.get_high_score(world_with_score) == 10

--- a/tests/ecs/test_scoring_system.py
+++ b/tests/ecs/test_scoring_system.py
@@ -393,3 +393,11 @@ class TestIntegration:
             """Eating apple increases the current score."""
             scoring_system.on_apple_eaten(world_with_score, points=10)
             assert scoring_system.get_current_score(world_with_score) == 10
+
+        def test_snake_length_overwrites_score(self, world_with_score, scoring_system):
+            """Score updates based on snake tail length."""
+            scoring_system.on_apple_eaten(world_with_score, points=10)
+            scoring_system.update_score_from_snake_length(
+                world_with_score, snake_tail_length=5
+            )
+            assert scoring_system.get_current_score(world_with_score) == 5

--- a/tests/ecs/test_scoring_system.py
+++ b/tests/ecs/test_scoring_system.py
@@ -409,3 +409,10 @@ class TestIntegration:
                 world_with_score, snake_tail_length=5
             )
             assert scoring_system.get_high_score(world_with_score) == 10
+
+        def test_reset_clears_current_only(self, world_with_score, scoring_system):
+            """Reset sets current score to zero but keeps high score."""
+            scoring_system.on_apple_eaten(world_with_score, points=10)
+            scoring_system.reset_current_score(world_with_score)
+            assert scoring_system.get_current_score(world_with_score) == 0
+            assert scoring_system.get_high_score(world_with_score) == 10

--- a/tests/ecs/test_scoring_system.py
+++ b/tests/ecs/test_scoring_system.py
@@ -385,3 +385,11 @@ class TestIntegration:
         # can still use apple eaten (though in real game, only one method is used)
         scoring_system.on_apple_eaten(world_with_score, points=5)
         assert scoring_system.get_current_score(world_with_score) == 15
+
+    class TestScoreEntityHelperBehavior:
+        """Tests that verify scoring still works correctly after refactoring."""
+
+        def test_apple_eaten_updates_score(self, world_with_score, scoring_system):
+            """Eating apple increases the current score."""
+            scoring_system.on_apple_eaten(world_with_score, points=10)
+            assert scoring_system.get_current_score(world_with_score) == 10


### PR DESCRIPTION
# Summary

Refactors the `ScoringSystem` by introducing a private helper method `_get_score_entity()` that centralizes the logic for locating the score entity. This replaces repeated lookup code across multiple scoring methods and improves readability and maintainability.

# Changes

- Added `_get_score_entity()` to `ScoringSystem`.
- Updated the following methods to use the new helper instead of duplicating lookup logic:
  - `on_apple_eaten`
  - `update_score_from_snake_length`
  - `reset_current_score`
  - `get_current_score`
  - `get_high_score`
  - `set_high_score`
  - `get_scores`
- Ensured no functional changes to scoring behavior.
- Added new unit tests validating the helper’s behavior:
  - apple eaten updates score using helper  
  - snake length overwrite updates score using helper  
  - high score remains highest after overwrite  
  - reset clears current but preserves high  
  - get_scores returns correct `(current, high)` tuple  
- Confirmed all pre-existing scoring tests pass unchanged.

# Motivation

This refactor removes repeated code and follows DRY principles, making `ScoringSystem` easier to maintain. Centralizing score-entity retrieval reduces risk of inconsistent logic across methods and helps future contributors understand the scoring workflow more clearly.

# Related Issue

Closes #399