### PR TITLE
[BUG] Fix Autoplay Mode Freeze After Wait-for-Input Feature

### DIFF
--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -31,6 +31,7 @@ from game.game_modes_registry import (
     CLASSIC_MODE_NAME,
     MOVING_APPLE_MODE_NAME,
     CHEESE_MODE_NAME,
+    AUTOPLAY_MODE_NAME,
 )
 
 
@@ -165,6 +166,10 @@ class GameInitializer:
 
         game_state_entity = GameStateEntity()
         world.registry.add(game_state_entity)
+
+        # Auto-start for Autoplay mode (AI-controlled, no user input)
+        if current_mode == AUTOPLAY_MODE_NAME:
+            game_state_entity.game_state.game_started = True
 
     def _create_color_scheme(self, world: World) -> None:
         """Create ColorScheme entity for rendering systems.

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -167,7 +167,7 @@ class GameInitializer:
         game_state_entity = GameStateEntity()
         world.registry.add(game_state_entity)
 
-        # Auto-start for Autoplay mode (AI-controlled, no user input)
+        # Auto-start for Autoplay mode (no user input)
         if current_mode == AUTOPLAY_MODE_NAME:
             game_state_entity.game_state.game_started = True
 


### PR DESCRIPTION
## Fix Autoplay Mode Freeze After Wait-for-Input Feature

This PR fixes a bug introduced in #385 (Cheese Mode) where Autoplay mode would freeze at startup.

### Problem
The `game_started` flag added in the Cheese Mode PR prevents snake movement until the player presses an arrow key. This broke Autoplay mode because:
- Autoplay has no user input
- Snake waits indefinitely for input that never comes
- Game appears frozen

### Solution
Auto-start Autoplay mode by setting `game_started=True` during initialization.

**Implementation** (`game_initializer.py`):
```python
# Auto-start for Autoplay mode (no user input)
if current_mode == AUTOPLAY_MODE_NAME:
    game_state_entity.game_state.game_started = True
```

### Changes
- Imported `AUTOPLAY_MODE_NAME` constant
- Added auto-start logic after GameState creation
- Autoplay now bypasses wait-for-input behavior

### Testing
Manually tested all game modes:
- ✅ **Classic**: Waits for first input
- ✅ **Cheese Mode**: Waits for first input  
- ✅ **Moving Apple**: Waits for first input
- ✅ **Autoplay**: Starts immediately

### Alternative Considered
Checking `game_mode` in the movement system was considered but rejected in favor of setting the flag at initialization for cleaner separation of concerns.

Fixes #422