### PR TITLE
refactor: add game_over_service

### DIFF
--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -37,6 +37,7 @@ from ecs.systems.scoring import ScoringSystem
 from game.settings import GameSettings
 from game.services.audio_service import AudioService
 from game.game_modes_registry import GAME_MODE_TELEPORT
+from game.services.game_over_service import GameOverService
 
 
 class CollisionSystem(BaseSystem):
@@ -69,6 +70,7 @@ class CollisionSystem(BaseSystem):
         settings: Optional[GameSettings] = None,
         audio_service: Optional[AudioService] = None,
         scoring_system: Optional[ScoringSystem] = None,
+        game_over_service: Optional[GameOverService] = None,
     ):
         """Initialize the CollisionSystem.
 
@@ -80,6 +82,7 @@ class CollisionSystem(BaseSystem):
         self._settings = settings
         self._audio_service = audio_service
         self._scoring_system = scoring_system
+        self._game_over_service = game_over_service
 
     def update(self, world: World) -> None:
         """Check for all collision types in priority order.
@@ -95,20 +98,17 @@ class CollisionSystem(BaseSystem):
         """
         # Check wall collision first (highest priority)
         if self._check_wall_collision(world):
-            print("☠️  DEATH CAUSE: Wall collision")
-            self._handle_death(world, "wall")
+            self._handle_death(world, "Wall collision")
             return
 
         # Check self-bite collision
         if self._check_self_bite(world):
-            print("☠️  DEATH CAUSE: Self-bite collision")
-            self._handle_death(world, "self-bite")
+            self._handle_death(world, "Self-bite collision")
             return
 
         # Check obstacle collision
         if self._check_obstacle_collision(world):
-            print("☠️  DEATH CAUSE: Obstacle collision")
-            self._handle_death(world, "obstacle")
+            self._handle_death(world, "Obstacle collision")
             return
 
         # Check apple collision (doesn't kill)
@@ -508,39 +508,12 @@ class CollisionSystem(BaseSystem):
     def _handle_death(self, world: World, reason: str) -> None:
         """Handle snake death.
 
-        Modifies GameState component and plays death audio.
-        Delegates score saving to the ScoringSystem.
-
-        Args:
-            world: ECS world
-            reason: Death reason message (e.g., "wall", "self-bite", "obstacle")
+        Delegates to GameOverService.
         """
-        # Get current score and save to scoreboard via scoring system
-        current_score = 0
-        if self._scoring_system:
-            current_score = self._scoring_system.get_current_score(world)
-            # Delegate scoreboard management to scoring system
-            self._scoring_system.save_score_to_scoreboard(world)
-
-        # kill the snake
-        snake = self._get_snake_entity(world)
-        if snake and hasattr(snake, "body"):
-            snake.body.alive = False
-
-        # play death sound and music
-        if self._audio_service:
-            self._audio_service.play_sound("assets/sound/gameover.wav")
-            self._audio_service.play_music("assets/sound/death_song.mp3")
-
-        # update game state
-        game_state = self._get_game_state(world)
-        if game_state:
-            game_state.game_over = True
-            game_state.death_reason = reason
-            game_state.next_scene = "game_over"
-            game_state.final_score = current_score  # Store score in GameState
-
-        print(f"GAME OVER: {reason}")
+        if self._game_over_service:
+            self._game_over_service.handle_death(world, reason)
+        else:
+            print(f"☠️ DEATH CAUSE: {reason} (Service missing)")
 
     def _should_swap_head_and_tail(self, world: World) -> bool:
         """Determine if apple effects should swap the snake head and tail."""

--- a/src/ecs/systems/hunger.py
+++ b/src/ecs/systems/hunger.py
@@ -23,11 +23,12 @@ This system manages the hunger countdown timer and handles death by starvation.
 When hunger reaches 0, the snake dies and the game ends.
 """
 
-from typing import Optional, Any
+from typing import Optional
 
 from ecs.systems.base_system import BaseSystem
 from ecs.world import World
 from ecs.entities.entity import EntityType
+from game.services.game_over_service import GameOverService
 
 
 class HungerSystem(BaseSystem):
@@ -47,13 +48,13 @@ class HungerSystem(BaseSystem):
     Hunger reset is triggered externally (e.g., by CollisionSystem on apple eaten).
     """
 
-    def __init__(self, audio_service: Optional[Any] = None):
+    def __init__(self, game_over_service: Optional[GameOverService] = None):
         """Initialize the HungerSystem.
 
         Args:
-            audio_service: Optional audio service for playing death sounds
+            game_over_service: Service for handling death logic
         """
-        self._audio_service = audio_service
+        self._game_over_service = game_over_service
 
     def update(self, world: World) -> None:
         """Decrement hunger timer and check for starvation.
@@ -195,26 +196,9 @@ class HungerSystem(BaseSystem):
     def _handle_starvation(self, world: World) -> None:
         """Handle snake death by starvation.
 
-        Modifies GameState component and plays death audio.
-
-        Args:
-            world: ECS world
+        Delegates to GameOverService.
         """
-        # Kill the snake
-        snake = self._get_snake_entity(world)
-        if snake and hasattr(snake, "body"):
-            snake.body.alive = False
-
-        # Play death sound and music
-        if self._audio_service:
-            self._audio_service.play_sound("assets/sound/gameover.wav")
-            self._audio_service.play_music("assets/sound/death_song.mp3")
-
-        # Update game state
-        game_state = self._get_game_state(world)
-        if game_state:
-            game_state.game_over = True
-            game_state.death_reason = "starvation"
-            game_state.next_scene = "game_over"
-
-        print("☠️  DEATH CAUSE: Starvation")
+        if self._game_over_service:
+            self._game_over_service.handle_death(world, "Starvation")
+        else:
+            print("☠️ DEATH CAUSE: Starvation (Service missing)")

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -49,6 +49,7 @@ from game.scenes.game_modes import get_resolved_game_mode
 from game.game_modes_registry import CLASSIC_MODE_NAME
 from ecs.systems.hunger import HungerSystem
 from game.settings import GameSettings
+from game.services.game_over_service import GameOverService
 
 
 class GameplayScene(BaseScene):
@@ -122,6 +123,11 @@ class GameplayScene(BaseScene):
             gamemode=self._current_game_mode,
         )
 
+        # Create GameOverService
+        game_over_service = GameOverService(
+            audio_service=self._audio_service, scoring_system=scoring_system
+        )
+
         # game logic systems (indices 0-7, paused during pause)
         from ecs.systems.apple_spawn import AppleSpawnSystem
         from ecs.systems.autoplay import AutoplaySystem
@@ -139,7 +145,10 @@ class GameplayScene(BaseScene):
                 ),  # 2: update entity positions based on velocity
                 MovingAppleSystem(),  # 3: move apples in modes that allow it
                 CollisionSystem(
-                    self._settings, self._audio_service, scoring_system
+                    self._settings,
+                    self._audio_service,
+                    scoring_system,
+                    game_over_service,
                 ),  # 4: detect collisions (wall, self-bite, obstacles, apples)
                 AppleSpawnSystem(1000),  # 5: maintain correct number of apples on board
                 SpawnSystem(
@@ -148,7 +157,7 @@ class GameplayScene(BaseScene):
                 ScoringSystem(),  # 7: track score and high score
                 # 8: conditionally enable HungerSystem based on game settings
                 *(
-                    [HungerSystem(self._audio_service)]
+                    [HungerSystem(game_over_service=game_over_service)]
                     if self._settings and bool(self._settings.get("enable_hunger"))
                     else []
                 ),

--- a/src/game/services/game_over_service.py
+++ b/src/game/services/game_over_service.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Game over service.
+
+This service is responsible for handling the game over logic when the snake dies.
+"""
+
+from typing import Optional
+
+from ecs.world import World
+from ecs.entities.entity import EntityType
+from game.services.audio_service import AudioService
+from ecs.systems.scoring import ScoringSystem
+
+
+class GameOverService:
+    """Service to centralize game over logic."""
+
+    def __init__(
+        self,
+        audio_service: Optional[AudioService] = None,
+        scoring_system: Optional[ScoringSystem] = None,
+    ):
+        self._audio_service = audio_service
+        self._scoring_system = scoring_system
+
+    def handle_death(self, world: World, reason: str) -> None:
+        """Handle snake death.
+
+        1. Calculate and save final score.
+        2. Mark snake as dead.
+        3. Play death SFX/Music.
+        4. Update GameState.
+
+        Args:
+            world: ECS world
+            reason: Death reason message (e.g., "wall", "self-bite", "obstacle")
+        """
+
+        # Get current score and save to scoreboard via scoring system
+        current_score = 0
+        if self._scoring_system:
+            current_score = self._scoring_system.get_current_score(world)
+            # Delegate scoreboard management to scoring system
+            self._scoring_system.save_score_to_scoreboard(world)
+
+        # kill the snake
+        snake = self._get_snake_entity(world)
+        if snake and hasattr(snake, "body"):
+            snake.body.alive = False
+
+        # play death sound and music
+        if self._audio_service:
+            self._audio_service.play_sound("assets/sound/gameover.wav")
+            self._audio_service.play_music("assets/sound/death_song.mp3")
+
+        # update game state
+        game_state = self._get_game_state(world)
+        if game_state:
+            game_state.game_over = True
+            game_state.death_reason = reason
+            game_state.next_scene = "game_over"
+            game_state.final_score = current_score  # Store score in GameState
+
+        print(f"☠️ DEATH CAUSE: {reason}")
+
+    def _get_snake_entity(self, world: World):
+        """Helper to find snake entity."""
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for _, snake in snakes.items():
+            return snake
+        return None
+
+    def _get_game_state(self, world: World):
+        """Helper to find game state entity."""
+        game_state_entities = world.registry.query_by_component("game_state")
+        if game_state_entities:
+            entity = next(iter(game_state_entities.values()))
+            if hasattr(entity, "game_state"):
+                return entity.game_state
+        return None


### PR DESCRIPTION
closes #425 

Changes in this PR:
- Moved the death logic from `collision.py` to its own service `game_over_service.py`.
- Updated the hunger and collision systems to use the new service.
- Initialized the new service in `gameplay.py`.

Tested with the 4 implemented death conditions (wall, self-bite, obstacles and hunger)