### PR TITLE
[Bug] Prevent text not fitting

### DIFF
--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -215,19 +215,27 @@ class GameModesScene(BaseScene):
                 rect = text.get_rect(center=(self._width / 2, current_y))
                 self._renderer.blit(text, rect)
 
-                # Draw description for currently navigated mode (centered)
+                # Draw description for currently navigated mode (centered, wrapped)
                 if i == self._selected_index:
                     description = self._get_description_for_index(i)
                     if description:
                         desc_y = current_y + int(self._height * 0.04)
                         if content_start_y <= desc_y <= content_end_y:
-                            desc_text = self._assets.render_custom(
-                                description, (120, 120, 120), int(self._width / 40)
+                            # Wrap text to fit screen width (85% of screen)
+                            wrapped_lines = self._wrap_text(
+                                description,
+                                int(self._width * 0.85),
+                                int(self._width / 50),
                             )
-                            desc_rect = desc_text.get_rect(
-                                center=(self._width / 2, desc_y)
-                            )
-                            self._renderer.blit(desc_text, desc_rect)
+                            for line_i, line in enumerate(wrapped_lines):
+                                line_y = desc_y + line_i * int(self._height * 0.025)
+                                desc_text = self._assets.render_custom(
+                                    line, (120, 120, 120), int(self._width / 50)
+                                )
+                                desc_rect = desc_text.get_rect(
+                                    center=(self._width / 2, line_y)
+                                )
+                                self._renderer.blit(desc_text, desc_rect)
 
             current_y += row_h
 
@@ -266,3 +274,43 @@ class GameModesScene(BaseScene):
         elif index == RANDOM_MODE_INDEX:
             return "Randomly selects one of the unlocked game modes."
         return None
+
+    def _wrap_text(self, text: str, max_width: int, font_size: int) -> list[str]:
+        """Wrap text to fit within max_width.
+        """
+        import pygame
+
+        font_path = "assets/font/GetVoIP-Grotesque.ttf"
+        try:
+            font = pygame.font.Font(font_path, font_size)
+        except Exception:
+            font = pygame.font.Font(None, font_size)
+
+        # If text fits in one line, return as is
+        test_surface = font.render(text, True, (255, 255, 255))
+        if test_surface.get_width() <= max_width:
+            return [text]
+
+        # Split text into words and wrap
+        words = text.split()
+        lines = []
+        current_line = []
+
+        for word in words:
+            test_line = " ".join(current_line + [word])
+            test_surface = font.render(test_line, True, (255, 255, 255))
+
+            if test_surface.get_width() <= max_width:
+                current_line.append(word)
+            else:
+                if current_line:
+                    lines.append(" ".join(current_line))
+                    current_line = [word]
+                else:
+                    # Single word is too long, add it anyway
+                    lines.append(word)
+
+        if current_line:
+            lines.append(" ".join(current_line))
+
+        return lines

--- a/src/game/scenes/game_modes.py
+++ b/src/game/scenes/game_modes.py
@@ -276,8 +276,7 @@ class GameModesScene(BaseScene):
         return None
 
     def _wrap_text(self, text: str, max_width: int, font_size: int) -> list[str]:
-        """Wrap text to fit within max_width.
-        """
+        """Wrap text to fit within max_width."""
         import pygame
 
         font_path = "assets/font/GetVoIP-Grotesque.ttf"

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -173,11 +173,18 @@ class GameOverScene(BaseScene):
             # Display top scores for current settings
             if self._scoreboard and self._settings:
                 y_offset += 100  # Increased spacing before high scores section
-                highscores_title = small_font.render(
-                    f"Top {MAX_SCOREBOARD_ENTRIES} Scores (Current Settings):",
-                    True,
-                    message_color,
-                )
+
+                # Use shorter text if width is too small
+                title_text = f"Top {MAX_SCOREBOARD_ENTRIES} Scores (Current Settings):"
+                highscores_title = small_font.render(title_text, True, message_color)
+
+                # If text doesn't fit, use shorter version
+                if highscores_title.get_width() > self._width * 0.95:
+                    title_text = f"Top {MAX_SCOREBOARD_ENTRIES} Scores:"
+                    highscores_title = small_font.render(
+                        title_text, True, message_color
+                    )
+
                 highscores_rect = highscores_title.get_rect(
                     center=(self._width // 2, y_offset)
                 )
@@ -257,11 +264,21 @@ class GameOverScene(BaseScene):
 
             # "Press Enter/Space to restart • Q to menu" text at bottom
             restart_text = small_font.render(
-                "Press Enter/Space to play again • Q to menu", True, message_color
+                "Press Enter/Space to play again  •  Q to menu", True, message_color
             )
             restart_rect = restart_text.get_rect(
                 center=(self._width // 2, self._height - 50)
             )
+
+            # If text doesn't fit, make it shorter
+            if restart_rect.width > self._width * 0.95:
+                restart_text = small_font.render(
+                    "Enter/Space: play  •  Q: menu", True, message_color
+                )
+                restart_rect = restart_text.get_rect(
+                    center=(self._width // 2, self._height - 50)
+                )
+
             self._renderer.blit(restart_text, restart_rect)
 
         except Exception as e:


### PR DESCRIPTION
## Description

Fixes text overflow issues in Game Modes menu and Game Over screen where long text would extend beyond screen boundaries.

## Related Issue
Closes #430

## Changes Made

- Game Modes menu: Implemented text wrapping for mode descriptions that splits long text into multiple lines when exceeding 85% of screen width

- Game Over screen: Added adaptive text sizing that automatically shortens text (high scores title and control hints) when window is too narrow

- All text now stays within visible screen boundaries regardless of window size