### PR TITLE
[BUG] Fix Checkerboard Pattern Breaking on Game Mode Switch

### DIFF
--- a/src/ecs/systems/board_render.py
+++ b/src/ecs/systems/board_render.py
@@ -106,13 +106,14 @@ class BoardRenderSystem(BaseSystem):
         arena_secondary_color = color_scheme.arena_secondary.to_tuple()
 
         # Draw secondary color tiles, for a checkerboard pattern
-        for index in range(0, board.width * board.height, 2):
-            x = (index % board.width) * cell_size
-            y = (index // board.width) * cell_size
-
-            self._renderer.draw_rect(
-                arena_secondary_color, pygame.Rect(x, y, cell_size, cell_size)
-            )
+        for y in range(board.height):
+            for x in range(board.width):
+                # Only draw tiles where (x + y) is even for proper checkerboard
+                if (x + y) % 2 == 0:
+                    self._renderer.draw_rect(
+                        arena_secondary_color,
+                        pygame.Rect(x * cell_size, y * cell_size, cell_size, cell_size),
+                    )
 
     def draw_tile(
         self, x: int, y: int, tile: Tile, cell_size: int, color_scheme: ColorScheme


### PR DESCRIPTION
This PR fixes the checkerboard pattern rendering bug that caused the board to display vertical stripes instead of a proper checkerboard pattern after switching game modes.

### Key Changes

#### Board Rendering (`board_render.py`)
- **Proper Checkerboard Algorithm**: Replaced flawed `range(0, width * height, 2)` iteration with nested loops
- **Modulo-Based Pattern**: Now uses `(x + y) % 2 == 0` check for mathematically correct checkerboard
- **Dimension-Independent**: Works correctly on both even and odd width/height boards
- **Persistent Across Mode Changes**: Pattern no longer breaks when `BoardRenderSystem` is re-initialized during game mode switching

### Root Cause
The original algorithm iterated through a linear index (`0, 2, 4, 6...`) and converted it to 2D coordinates. This created vertical stripes on even-width boards because:
- On a 10×10 board: `index=10` → `(0,1)` instead of correct checkerboard position `(1,1)`
- Pattern degraded every time `BoardRenderSystem` was recreated during mode switching

### Visual Behavior

https://github.com/user-attachments/assets/11f58a97-5a36-4ae9-a1e6-4dff82f71565

### Testing
- [x] Manually verified pattern in Classic mode
- [x] Tested mode switching (Classic → Cheese → Moving Apple)
- [x] Confirmed pattern remains consistent across all transitions
- [x] No regression in existing gameplay mechanics

Closes #433