### PR TITLE
[FEAT] Add board color options

### DIFF
--- a/src/ecs/systems/board_render.py
+++ b/src/ecs/systems/board_render.py
@@ -84,13 +84,14 @@ class BoardRenderSystem(BaseSystem):
         return ColorScheme()
 
     def clear_screen(self, world: World) -> None:
-        """Clear the screen with black background for border effect.
+        """Clear the screen with grid color background for border effect.
 
         Args:
             world: Game world
         """
-        # Fill entire screen with black for border
-        self._renderer.fill((0, 0, 0))
+        # Fill entire screen with grid color for border
+        color_scheme = self._get_color_scheme(world)
+        self._renderer.fill(color_scheme.grid.to_tuple())
 
     def get_board_offset(self) -> tuple[int, int]:
         """Get the offset for the game board from screen edge.

--- a/src/ecs/systems/settings_apply.py
+++ b/src/ecs/systems/settings_apply.py
@@ -64,6 +64,7 @@ class SettingsApplySystem(BaseSystem):
         # track previous settings to detect changes
         self._previous_cells_per_side = None
         self._previous_palette = None
+        self._previous_board_palette = None
         self._previous_initial_speed = None
         self._previous_max_speed = None
         self._previous_obstacle_difficulty = None
@@ -90,6 +91,7 @@ class SettingsApplySystem(BaseSystem):
         # check and apply each setting type
         self._check_and_apply_grid_size(world)
         self._check_and_apply_palette(world)
+        self._check_and_apply_board_palette(world)
         self._check_and_apply_speeds(world)
         self._check_and_apply_obstacle_difficulty(world)
 
@@ -100,6 +102,7 @@ class SettingsApplySystem(BaseSystem):
 
         self._previous_cells_per_side = self._settings.get("cells_per_side")
         self._previous_palette = self._get_current_palette_key()
+        self._previous_board_palette = self._get_current_board_palette_key()
         self._previous_initial_speed = self._settings.get("initial_speed")
         self._previous_max_speed = self._settings.get("max_speed")
         self._previous_obstacle_difficulty = self._settings.get("obstacle_difficulty")
@@ -229,6 +232,60 @@ class SettingsApplySystem(BaseSystem):
                 snake.renderable.color = head_color
                 snake.renderable.secondary_color = tail_color
                 print(f"Applied palette: head={head_color_hex}, tail={tail_color_hex}")
+                break
+
+    def _get_current_board_palette_key(self) -> str:
+        """Get a unique key representing current board palette colors.
+
+        Returns:
+            String key combining primary, secondary, and grid colors
+        """
+        board_colors = self._settings.get_board_colors()
+        return f"{board_colors['primary']}_{board_colors['secondary']}_{board_colors['grid']}"
+
+    def _check_and_apply_board_palette(self, world: World) -> None:
+        """Check if board palette changed and apply it.
+
+        Args:
+            world: ECS world instance
+        """
+        current_board_palette = self._get_current_board_palette_key()
+        if current_board_palette == self._previous_board_palette:
+            return
+
+        # board palette changed, apply it
+        self._apply_board_palette_change(world)
+        self._previous_board_palette = current_board_palette
+
+    def _apply_board_palette_change(self, world: World) -> None:
+        """Apply board palette change to ColorScheme entity.
+
+        Args:
+            world: ECS world instance
+        """
+        # get the colors from the current board palette
+        board_colors = self._settings.get_board_colors()
+        primary_hex = board_colors.get("primary")
+        secondary_hex = board_colors.get("secondary")
+        grid_hex = board_colors.get("grid")
+
+        # convert hex colors to Color objects
+        from core.types.color import Color
+
+        primary_color = Color.from_hex(primary_hex)
+        secondary_color = Color.from_hex(secondary_hex)
+        grid_color = Color.from_hex(grid_hex)
+
+        # find the ColorScheme entity and update its colors
+        for entity_id, entity in world.registry.all_entities.items():
+            if hasattr(entity, "color_scheme"):
+                entity.color_scheme.arena = primary_color
+                entity.color_scheme.arena_secondary = secondary_color
+                entity.color_scheme.grid = grid_color
+                print(
+                    f"Applied board palette: primary={primary_hex}, "
+                    f"secondary={secondary_hex}, grid={grid_hex}"
+                )
                 break
 
     def _check_and_apply_speeds(self, world: World) -> None:

--- a/src/ecs/systems/settings_apply.py
+++ b/src/ecs/systems/settings_apply.py
@@ -277,16 +277,16 @@ class SettingsApplySystem(BaseSystem):
         grid_color = Color.from_hex(grid_hex)
 
         # find the ColorScheme entity and update its colors
-        for entity_id, entity in world.registry.all_entities.items():
-            if hasattr(entity, "color_scheme"):
-                entity.color_scheme.arena = primary_color
-                entity.color_scheme.arena_secondary = secondary_color
-                entity.color_scheme.grid = grid_color
-                print(
-                    f"Applied board palette: primary={primary_hex}, "
-                    f"secondary={secondary_hex}, grid={grid_hex}"
-                )
-                break
+        color_entities = world.registry.query_by_component("color_scheme")
+        for entity_id, entity in color_entities.items():
+            entity.color_scheme.arena = primary_color
+            entity.color_scheme.arena_secondary = secondary_color
+            entity.color_scheme.grid = grid_color
+            print(
+                f"Applied board palette: primary={primary_hex}, "
+                f"secondary={secondary_hex}, grid={grid_hex}"
+            )
+            break
 
     def _check_and_apply_speeds(self, world: World) -> None:
         """Check if speeds changed and apply them.

--- a/src/game/constants.py
+++ b/src/game/constants.py
@@ -102,6 +102,52 @@ SNAKE_COLOR_PALETTES = [
     {"head": "#ff0000", "tail": "#rainbow", "name": "Rainbow"},
 ]
 
+# Color palettes for board customization (from Figma design)
+BOARD_COLOR_PALETTES = [
+    # Classic Dark (default)
+    {
+        "primary": "#202020",
+        "secondary": "#2c2c2c",
+        "grid": "#3c3c3b",
+        "name": "Classic Dark",
+    },
+    # Pink
+    {
+        "primary": "#E780A0",
+        "secondary": "#DE527F",
+        "grid": "#5C2436",
+        "name": "Pink",
+    },
+    # Orange
+    {
+        "primary": "#FFC073",
+        "secondary": "#F8961E",
+        "grid": "#613C0F",
+        "name": "Orange",
+    },
+    # Green
+    {
+        "primary": "#BDDCA5",
+        "secondary": "#90BE6D",
+        "grid": "#3F5230",
+        "name": "Green",
+    },
+    # Blue
+    {
+        "primary": "#97AABB",
+        "secondary": "#577590",
+        "grid": "#2C3B49",
+        "name": "Blue",
+    },
+    # Purple
+    {
+        "primary": "#C17CD8",
+        "secondary": "#8D41A6",
+        "grid": "#41204C",
+        "name": "Purple",
+    },
+]
+
 # Rainbow colors for the Rainbow skin (ROYGBIV spectrum)
 RAINBOW_COLORS = [
     "#ff0000",  # Red
@@ -148,3 +194,28 @@ def get_snake_colors_by_name(name: str):
         if palette["name"] == name:
             return palette
     return SNAKE_COLOR_PALETTES[0]  # Return default if not found
+
+
+def get_random_board_colors():
+    """Get a random color palette for the board.
+
+    Returns:
+        dict: Dictionary with 'primary', 'secondary', 'grid', and 'name' keys
+    """
+    return random.choice(BOARD_COLOR_PALETTES)
+
+
+def get_board_colors_by_name(name: str):
+    """Get board colors by palette name.
+
+    Args:
+        name: Name of the color palette
+
+    Returns:
+        dict: Dictionary with 'primary', 'secondary', 'grid', and 'name' keys,
+              or default if not found
+    """
+    for palette in BOARD_COLOR_PALETTES:
+        if palette["name"] == name:
+            return palette
+    return BOARD_COLOR_PALETTES[0]  # Return default if not found

--- a/src/game/constants.py
+++ b/src/game/constants.py
@@ -104,11 +104,11 @@ SNAKE_COLOR_PALETTES = [
 
 # Color palettes for board customization (from Figma design)
 BOARD_COLOR_PALETTES = [
-    # Classic Dark (default)
+    # Classic Dark (default) - uses black border
     {
         "primary": "#202020",
         "secondary": "#2c2c2c",
-        "grid": "#3c3c3b",
+        "grid": "#000000",
         "name": "Classic Dark",
     },
     # Pink

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -200,10 +200,21 @@ class GameInitializer:
             world: ECS world instance
         """
         from ecs.components.color_scheme import ColorScheme
+        from core.types.color import Color
+
+        # Get board colors from settings
+        board_colors = self._settings.get_board_colors()
+        primary_hex = board_colors.get("primary")
+        secondary_hex = board_colors.get("secondary")
+        grid_hex = board_colors.get("grid")
 
         class ColorSchemeEntity:
             def __init__(self):
                 self.color_scheme = ColorScheme()
+                # Apply board colors from settings
+                self.color_scheme.arena = Color.from_hex(primary_hex)
+                self.color_scheme.arena_secondary = Color.from_hex(secondary_hex)
+                self.color_scheme.grid = Color.from_hex(grid_hex)
 
             def get_type(self):
                 return None  # config entity has no specific type

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -24,7 +24,7 @@ from types import FunctionType
 from typing import Any
 import os
 import json
-from .constants import SNAKE_COLOR_PALETTES, USER_DATA_DIR
+from .constants import SNAKE_COLOR_PALETTES, BOARD_COLOR_PALETTES, USER_DATA_DIR
 
 
 class GameSettings:
@@ -41,7 +41,8 @@ class GameSettings:
         "sound_effects": True,  # Controls all sound effects (eat, death, etc.)
         "dynamic_spawn_obstacles": False,
         "electric_walls": True,
-        "snake_color_palette": "Classic Green",  # New setting
+        "snake_color_palette": "Classic Green",  # Snake color customization
+        "board_color_palette": "Classic Dark",  # Board color customization
         "speed_increase_rate": "10%",  # Speed increase per apple: 5% or 10%
         "enable_hunger": False,
     }
@@ -156,6 +157,14 @@ class GameSettings:
             "label": "Snake color",
             "type": "select",
             "options": [palette["name"] for palette in SNAKE_COLOR_PALETTES],
+            "requires_reset": False,
+            "category": "Display",
+        },
+        {
+            "key": "board_color_palette",
+            "label": "Board color",
+            "type": "select",
+            "options": [palette["name"] for palette in BOARD_COLOR_PALETTES],
             "requires_reset": False,
             "category": "Display",
         },
@@ -486,6 +495,17 @@ class GameSettings:
 
         palette_name = self.settings.get("snake_color_palette", "Classic Green")
         return get_snake_colors_by_name(palette_name)
+
+    def get_board_colors(self):
+        """Get current board colors based on selected palette.
+
+        Returns:
+            dict: Dictionary with 'primary', 'secondary', 'grid', and 'name' keys
+        """
+        from .constants import get_board_colors_by_name
+
+        palette_name = self.settings.get("board_color_palette", "Classic Dark")
+        return get_board_colors_by_name(palette_name)
 
     def randomize_snake_colors(self):
         """Randomize snake colors to a random palette.


### PR DESCRIPTION
## Description
Adds customizable board color palettes to the settings menu, allowing players to change the color of the game board.

## Related Issue
Closes #444

## Changes Made
- Added 6 board color palettes (Pink, Orange, Green, Blue, Purple, Classic Dark)
- Each palette has primary (light), secondary (medium), and grid/border (dark) colors
- Added "Board color" setting in Display category
- Colors update in real-time during gameplay
- Board border uses grid color from selected palette