### PR TITLE
[FEAT] Add Speed Boost Mode in Settings with temporary speed increase

### DIFF
--- a/src/ecs/components/__init__.py
+++ b/src/ecs/components/__init__.py
@@ -33,6 +33,7 @@ from ecs.components.game_state import GameState
 from ecs.components.score import Score
 from ecs.components.moving_apple import MovingApple
 from ecs.components.input_buffer import InputBuffer
+from ecs.components.trail_obstacle import TrailObstacleTag
 
 __all__ = [
     "Position",
@@ -50,4 +51,5 @@ __all__ = [
     "Score",
     "MovingApple",
     "InputBuffer",
+    "TrailObstacleTag",
 ]

--- a/src/ecs/components/game_state.py
+++ b/src/ecs/components/game_state.py
@@ -50,6 +50,7 @@ class GameState:
     cheese_mode_enabled: bool = False
     trail_mode_enabled: bool = False
     shrinking_mode_enabled: bool = False
+    speed_boost_mode_enabled: bool = False
     game_started: bool = False  # Set to True after first input
     final_score: int = 0  # score at time of death
     trail_obstacles: List[Tuple[int, int]] = field(default_factory=list)

--- a/src/ecs/components/game_state.py
+++ b/src/ecs/components/game_state.py
@@ -54,4 +54,3 @@ class GameState:
     game_started: bool = False  # Set to True after first input
     final_score: int = 0  # score at time of death
     trail_obstacles: List[Tuple[int, int]] = field(default_factory=list)
-

--- a/src/ecs/components/game_state.py
+++ b/src/ecs/components/game_state.py
@@ -48,6 +48,9 @@ class GameState:
     moving_apples_enabled: bool = False
     swap_head_tail_on_apple: bool = False
     cheese_mode_enabled: bool = False
+    trail_mode_enabled: bool = False
     shrinking_mode_enabled: bool = False
     game_started: bool = False  # Set to True after first input
     final_score: int = 0  # score at time of death
+    trail_obstacles: List[Tuple[int, int]] = field(default_factory=list)
+

--- a/src/ecs/components/speed_boost.py
+++ b/src/ecs/components/speed_boost.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Speed boost component for Speed Boost Mode.
+
+Tracks the state of temporary speed boosts granted when eating apples.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SpeedBoost:
+    """Component tracking speed boost state.
+
+    Used by: Snake entity (when Speed Boost Mode is enabled)
+    Read by: MovementSystem (to apply speed multiplier)
+    Written by: SpeedBoostSystem (to manage boost timing)
+
+    Attributes:
+        active: Whether the speed boost is currently active
+        remaining_time: Time left in seconds before boost expires
+        multiplier: Speed multiplier applied when boost is active
+        duration: Total duration of boost in seconds
+    """
+
+    active: bool = False
+    remaining_time: float = 0.0
+    multiplier: float = 2.0  # 2x speed when boosted
+    duration: float = 3.0  # boost lasts 3 seconds
+
+    def activate(self) -> None:
+        """Activate the speed boost and reset the timer."""
+        self.active = True
+        self.remaining_time = self.duration
+
+    def deactivate(self) -> None:
+        """Deactivate the speed boost."""
+        self.active = False
+        self.remaining_time = 0.0

--- a/src/ecs/components/trail_obstacle.py
+++ b/src/ecs/components/trail_obstacle.py
@@ -29,7 +29,7 @@ class TrailObstacleTag:
     Tag-only component with no data fields.
     Differentiates trail obstacles (created during gameplay) from
     static obstacles (created at level start).
-    
+
     Used by: TrailObstacle entities
     Read by: CollisionSystem, rendering systems
     """

--- a/src/ecs/components/trail_obstacle.py
+++ b/src/ecs/components/trail_obstacle.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Trail obstacle component for Trail Mode."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TrailObstacleTag:
+    """Marker component for trail obstacle entities in Trail Mode.
+
+    Tag-only component with no data fields.
+    Differentiates trail obstacles (created during gameplay) from
+    static obstacles (created at level start).
+    
+    Used by: TrailObstacle entities
+    Read by: CollisionSystem, rendering systems
+    """

--- a/src/ecs/entities/snake.py
+++ b/src/ecs/entities/snake.py
@@ -20,6 +20,7 @@
 """Snake entity."""
 
 from dataclasses import dataclass
+from typing import Optional
 
 from ecs.entities.entity import Entity, EntityType
 from ecs.components.position import Position
@@ -29,6 +30,7 @@ from ecs.components.interpolation import Interpolation
 from ecs.components.renderable import Renderable
 from ecs.components.input_buffer import InputBuffer
 from ecs.components.hunger import Hunger
+from ecs.components.speed_boost import SpeedBoost
 
 
 @dataclass
@@ -41,6 +43,7 @@ class Snake(Entity):
     - body: tail segments as Position list
     - interpolation: smooth rendering data
     - renderable: visual appearance (contains head color)
+    - speed_boost: optional speed boost state (Speed Boost Mode)
 
     Note: Snake colors are now stored in renderable.color (head) and
     retrieved from ColorScheme or constants for tail color.
@@ -53,6 +56,7 @@ class Snake(Entity):
     renderable: Renderable
     input_buffer: InputBuffer
     hunger: Hunger
+    speed_boost: Optional[SpeedBoost] = None
 
     def get_type(self) -> EntityType:
         """Get the type of this entity.

--- a/src/ecs/entities/trail_obstacle.py
+++ b/src/ecs/entities/trail_obstacle.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Trail obstacle entity for Trail Mode."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ecs.entities.entity import Entity, EntityType
+from ecs.components.position import Position
+from ecs.components.trail_obstacle import TrailObstacleTag
+from ecs.components.renderable import Renderable
+
+
+@dataclass
+class TrailObstacle(Entity):
+    """Trail obstacle entity created during Trail Mode gameplay.
+
+    Trail obstacles are dynamically created as the snake moves,
+    marking every position the snake's head passes through.
+    
+    Components:
+    - position: location in grid where trail was left
+    - tag: marker to identify as trail obstacle
+    - renderable: visual representation (optional, for ECS rendering)
+    """
+
+    position: Position
+    tag: TrailObstacleTag
+    renderable: Optional[Renderable] = None
+
+    def get_type(self) -> EntityType:
+        """Get the type of this entity.
+
+        Returns:
+            EntityType.OBSTACLE (trail obstacles are treated as obstacles)
+        """
+        return EntityType.OBSTACLE

--- a/src/ecs/entities/trail_obstacle.py
+++ b/src/ecs/entities/trail_obstacle.py
@@ -34,7 +34,7 @@ class TrailObstacle(Entity):
 
     Trail obstacles are dynamically created as the snake moves,
     marking every position the snake's head passes through.
-    
+
     Components:
     - position: location in grid where trail was left
     - tag: marker to identify as trail obstacle

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -29,6 +29,7 @@ from ecs.components.interpolation import Interpolation
 from ecs.components.renderable import Renderable
 from ecs.components.input_buffer import InputBuffer
 from ecs.components.hunger import Hunger
+from ecs.components.speed_boost import SpeedBoost
 from core.types.color import Color
 from game import constants
 
@@ -43,6 +44,7 @@ def create_snake(
     cheese_mode: bool = False,
     shrinking_mode: bool = False,
     autoplay_mode: bool = False,
+    speed_boost_mode: bool = False,
 ) -> int:
     """Create a snake entity with all required components.
 
@@ -56,6 +58,7 @@ def create_snake(
         cheese_mode: Whether Cheese Mode is enabled (affects initial size)
         shrinking_mode: Whether Shrinking Mode is enabled (starts large)
         autoplay_mode: Whether Autoplay Mode is enabled (starts with zero velocity)
+        speed_boost_mode: Whether Speed Boost Mode is enabled (adds SpeedBoost component)
 
     Returns:
         int: Entity ID of created snake
@@ -132,6 +135,7 @@ def create_snake(
             size=grid_size,
         ),
         input_buffer=InputBuffer(),
+        speed_boost=SpeedBoost() if speed_boost_mode else None,
     )
 
     # register entity with world and return ID

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -733,6 +733,11 @@ class CollisionSystem(BaseSystem):
                     if game_state:
                         game_state.apples_eaten_count += 1
 
+                        # Activate speed boost if Speed Boost Mode is enabled
+                        if game_state.speed_boost_mode_enabled:
+                            if hasattr(snake, "speed_boost") and snake.speed_boost:
+                                snake.speed_boost.activate()
+
                     # increase speed by 10%, respect max_speed
                     # NOTE: keep speed constant when shrinking mode is enabled to avoid complications
                     if not shrinking_mode and hasattr(snake, "velocity"):

--- a/src/ecs/systems/movement.py
+++ b/src/ecs/systems/movement.py
@@ -69,6 +69,11 @@ class MovementSystem(BaseSystem):
         else:
             speed = 12.0  # default speed
 
+        # Apply speed boost multiplier if active
+        if hasattr(first_snake, "speed_boost") and first_snake.speed_boost:
+            if first_snake.speed_boost.active:
+                speed *= first_snake.speed_boost.multiplier
+
         # Calculate how long one grid cell movement should take
         move_interval_ms = 1000.0 / speed
 

--- a/src/ecs/systems/speed_boost.py
+++ b/src/ecs/systems/speed_boost.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Speed boost system for Speed Boost Mode.
+
+Manages the lifecycle of speed boosts, including timing and deactivation.
+"""
+
+from __future__ import annotations
+
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
+
+
+class SpeedBoostSystem(BaseSystem):
+    """System for managing speed boost timing in Speed Boost Mode.
+
+    Reads: GameState (speed_boost_mode_enabled), SpeedBoost component
+    Writes: SpeedBoost (remaining_time, active)
+
+    Responsibilities:
+    - Decrement boost timer each frame
+    - Deactivate boost when timer reaches zero
+    - Only process when Speed Boost Mode is enabled
+    """
+
+    def update(self, world: World) -> None:
+        """Update speed boost timers for all snakes.
+
+        Args:
+            world: ECS world instance
+        """
+        # Check if Speed Boost Mode is enabled
+        game_state_entities = world.registry.query_by_component("game_state")
+        if not game_state_entities:
+            return
+
+        game_state_entity = next(iter(game_state_entities.values()))
+        if not hasattr(game_state_entity, "game_state"):
+            return
+
+        game_state = game_state_entity.game_state
+
+        # Only process if speed boost mode is enabled
+        if not game_state.speed_boost_mode_enabled:
+            return
+
+        # Get delta time in seconds
+        dt_seconds = world.dt_ms / 1000.0
+
+        # Get all snakes with speed_boost component
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+
+        for _, snake in snakes.items():
+            # Skip snakes without speed_boost component
+            if not hasattr(snake, "speed_boost") or snake.speed_boost is None:
+                continue
+
+            speed_boost = snake.speed_boost
+
+            # Process only active boosts
+            if speed_boost.active:
+                # Decrement timer
+                speed_boost.remaining_time -= dt_seconds
+
+                # Deactivate if timer expired
+                if speed_boost.remaining_time <= 0:
+                    speed_boost.deactivate()

--- a/src/ecs/systems/trail_generation.py
+++ b/src/ecs/systems/trail_generation.py
@@ -57,7 +57,7 @@ class TrailGenerationSystem(BaseSystem):
 
     def __init__(self):
         """Initialize the trail generation system.
-        
+
         Tracks the snake's previous head position to determine where
         to place trail obstacles.
         """

--- a/src/ecs/systems/trail_generation.py
+++ b/src/ecs/systems/trail_generation.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Trail generation system for Trail Mode.
+
+This system creates permanent obstacles at positions where the snake's head
+has been, progressively filling the board as the game continues.
+"""
+
+from __future__ import annotations
+
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
+from ecs.entities.trail_obstacle import TrailObstacle
+from ecs.components.position import Position
+from ecs.components.trail_obstacle import TrailObstacleTag
+from ecs.components.renderable import Renderable
+from core.types.color import Color
+
+
+# Trail obstacle color - darker than regular obstacles for distinction
+TRAIL_OBSTACLE_COLOR = "#4a4a4a"
+
+
+class TrailGenerationSystem(BaseSystem):
+    """System for generating trail obstacles in Trail Mode.
+
+    Reads: Position (snake head), GameState (trail_mode_enabled)
+    Writes: New TrailObstacle entities, GameState.trail_obstacles
+
+    Responsibilities:
+    - Track snake head's previous positions
+    - Create trail obstacle entities when snake moves
+    - Update game state's trail obstacles list
+    - Only activate when trail_mode_enabled is True
+
+    The system creates a permanent obstacle at each position the snake's
+    head moves from, making the game progressively more difficult.
+    """
+
+    def __init__(self):
+        """Initialize the trail generation system.
+        
+        Tracks the snake's previous head position to determine where
+        to place trail obstacles.
+        """
+        self._previous_head_positions = {}  # {entity_id: (x, y)}
+
+    def update(self, world: World) -> None:
+        """Update trail obstacles based on snake movement.
+
+        Args:
+            world: ECS world instance
+        """
+        # Check if Trail Mode is enabled
+        game_state_entities = world.registry.query_by_component("game_state")
+        if not game_state_entities:
+            return
+
+        game_state_entity = next(iter(game_state_entities.values()))
+        if not hasattr(game_state_entity, "game_state"):
+            return
+
+        game_state = game_state_entity.game_state
+
+        # Only process if trail mode is enabled and game has started
+        if not game_state.trail_mode_enabled or not game_state.game_started:
+            return
+
+        # Get all snakes
+        snakes = world.registry.query_by_type_and_components(
+            EntityType.SNAKE, "position", "body"
+        )
+
+        for entity_id, snake in snakes.items():
+            # Skip dead snakes
+            if not snake.body.alive:
+                continue
+
+            current_pos = (snake.position.x, snake.position.y)
+
+            # Check if we have a previous position for this snake
+            if entity_id in self._previous_head_positions:
+                prev_pos = self._previous_head_positions[entity_id]
+
+                # If the snake has moved, create a trail obstacle at the previous position
+                if prev_pos != current_pos:
+                    # Don't create trail obstacle if one already exists at this position
+                    if prev_pos not in game_state.trail_obstacles:
+                        self._create_trail_obstacle(world, prev_pos[0], prev_pos[1])
+                        game_state.trail_obstacles.append(prev_pos)
+
+            # Update the previous position for next frame
+            self._previous_head_positions[entity_id] = current_pos
+
+    def _create_trail_obstacle(self, world: World, x: int, y: int) -> int:
+        """Create a trail obstacle entity at the specified position.
+
+        Args:
+            world: ECS world instance
+            x: X coordinate for the obstacle
+            y: Y coordinate for the obstacle
+
+        Returns:
+            Entity ID of the created trail obstacle
+        """
+        grid_size = world.board.cell_size
+        color = Color.from_hex(TRAIL_OBSTACLE_COLOR)
+
+        trail_obstacle = TrailObstacle(
+            position=Position(x=x, y=y),
+            tag=TrailObstacleTag(),
+            renderable=Renderable(
+                shape="square",
+                color=color,
+                size=grid_size,
+            ),
+        )
+
+        return world.registry.add(trail_obstacle)

--- a/src/game/game_modes_registry.py
+++ b/src/game/game_modes_registry.py
@@ -29,6 +29,7 @@ AUTOPLAY_MODE_NAME = "AutoPlay"
 SHRINKING_MODE_NAME = "Shrinking Mode"
 GAME_MODE_TELEPORT = "Teleport"
 BOX_MODE_NAME = "Box Mode"
+TRAIL_MODE_NAME = "Trail Mode"
 
 ACTUAL_GAME_MODES = [
     {
@@ -63,6 +64,10 @@ ACTUAL_GAME_MODES = [
         "name": BOX_MODE_NAME,
         "description": "Push boxes into holes to earn points.",
     },
+    {
+        "name": TRAIL_MODE_NAME,
+        "description": "Every tile the snake moves through becomes a permanent obstacle.",
+    },
 ]
 
 RANDOM_MODE_LABEL = "Random"
@@ -75,6 +80,7 @@ __all__ = [
     "AUTOPLAY_MODE_NAME",
     "GAME_MODE_TELEPORT",
     "BOX_MODE_NAME",
+    "TRAIL_MODE_NAME",
     "ACTUAL_GAME_MODES",
     "RANDOM_MODE_LABEL",
     "RANDOM_MODE_INDEX",

--- a/src/game/game_modes_registry.py
+++ b/src/game/game_modes_registry.py
@@ -30,6 +30,7 @@ SHRINKING_MODE_NAME = "Shrinking Mode"
 GAME_MODE_TELEPORT = "Teleport"
 BOX_MODE_NAME = "Box Mode"
 TRAIL_MODE_NAME = "Trail Mode"
+SPEED_BOOST_MODE_NAME = "Speed Boost Mode"
 
 ACTUAL_GAME_MODES = [
     {
@@ -68,6 +69,10 @@ ACTUAL_GAME_MODES = [
         "name": TRAIL_MODE_NAME,
         "description": "Every tile the snake moves through becomes a permanent obstacle.",
     },
+    {
+        "name": SPEED_BOOST_MODE_NAME,
+        "description": "Eating apples grants temporary 2x speed boost for 3 seconds.",
+    },
 ]
 
 RANDOM_MODE_LABEL = "Random"
@@ -81,6 +86,7 @@ __all__ = [
     "GAME_MODE_TELEPORT",
     "BOX_MODE_NAME",
     "TRAIL_MODE_NAME",
+    "SPEED_BOOST_MODE_NAME",
     "ACTUAL_GAME_MODES",
     "RANDOM_MODE_LABEL",
     "RANDOM_MODE_INDEX",

--- a/src/game/game_modes_registry.py
+++ b/src/game/game_modes_registry.py
@@ -30,7 +30,6 @@ SHRINKING_MODE_NAME = "Shrinking Mode"
 GAME_MODE_TELEPORT = "Teleport"
 BOX_MODE_NAME = "Box Mode"
 TRAIL_MODE_NAME = "Trail Mode"
-SPEED_BOOST_MODE_NAME = "Speed Boost Mode"
 
 ACTUAL_GAME_MODES = [
     {
@@ -69,10 +68,6 @@ ACTUAL_GAME_MODES = [
         "name": TRAIL_MODE_NAME,
         "description": "Every tile the snake moves through becomes a permanent obstacle.",
     },
-    {
-        "name": SPEED_BOOST_MODE_NAME,
-        "description": "Eating apples grants temporary 2x speed boost for 3 seconds.",
-    },
 ]
 
 RANDOM_MODE_LABEL = "Random"
@@ -86,7 +81,6 @@ __all__ = [
     "GAME_MODE_TELEPORT",
     "BOX_MODE_NAME",
     "TRAIL_MODE_NAME",
-    "SPEED_BOOST_MODE_NAME",
     "ACTUAL_GAME_MODES",
     "RANDOM_MODE_LABEL",
     "RANDOM_MODE_INDEX",

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -46,6 +46,7 @@ from ecs.systems.overlay_render import OverlayRenderSystem
 from ecs.systems.obstacle_generation import ObstacleGenerationSystem
 from ecs.systems.settings_apply import SettingsApplySystem
 from ecs.systems.trail_generation import TrailGenerationSystem
+from ecs.systems.speed_boost import SpeedBoostSystem
 from game.scenes.game_modes import get_resolved_game_mode
 from game.game_modes_registry import CLASSIC_MODE_NAME, BOX_MODE_NAME
 from ecs.systems.hunger import HungerSystem
@@ -147,6 +148,7 @@ class GameplayScene(BaseScene):
                 self._get_electric_walls
             ),  # 2: update entity positions based on velocity
             TrailGenerationSystem(),  # 3: create trail obstacles in Trail Mode
+            SpeedBoostSystem(),  # 4: manage speed boost timing
         ]
 
         # add apple-related systems only if not in Box Mode

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -45,6 +45,7 @@ from ecs.systems.ui_render import UIRenderSystem
 from ecs.systems.overlay_render import OverlayRenderSystem
 from ecs.systems.obstacle_generation import ObstacleGenerationSystem
 from ecs.systems.settings_apply import SettingsApplySystem
+from ecs.systems.trail_generation import TrailGenerationSystem
 from game.scenes.game_modes import get_resolved_game_mode
 from game.game_modes_registry import CLASSIC_MODE_NAME, BOX_MODE_NAME
 from ecs.systems.hunger import HungerSystem
@@ -145,13 +146,14 @@ class GameplayScene(BaseScene):
             MovementSystem(
                 self._get_electric_walls
             ),  # 2: update entity positions based on velocity
+            TrailGenerationSystem(),  # 3: create trail obstacles in Trail Mode
         ]
 
         # add apple-related systems only if not in Box Mode
         if self._current_game_mode != BOX_MODE_NAME:
             game_logic_systems.extend(
                 [
-                    MovingAppleSystem(),  # 3: move apples in modes that allow it
+                    MovingAppleSystem(),  # 4: move apples in modes that allow it
                 ]
             )
 

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -35,6 +35,7 @@ from game.game_modes_registry import (
     SHRINKING_MODE_NAME,
     AUTOPLAY_MODE_NAME,
     BOX_MODE_NAME,
+    TRAIL_MODE_NAME,
 )
 
 
@@ -180,6 +181,7 @@ class GameInitializer:
             and self._settings.get("swap_head_tail_on_apple")
         )
         cheese_mode_enabled = current_mode == CHEESE_MODE_NAME
+        trail_mode_enabled = current_mode == TRAIL_MODE_NAME
         shrinking_mode_enabled = current_mode == SHRINKING_MODE_NAME
 
         class GameStateEntity:
@@ -193,6 +195,7 @@ class GameInitializer:
                     moving_apples_enabled=moving_apples_enabled,
                     swap_head_tail_on_apple=swap_head_tail_enabled,
                     cheese_mode_enabled=cheese_mode_enabled,
+                    trail_mode_enabled=trail_mode_enabled,
                     shrinking_mode_enabled=shrinking_mode_enabled,
                 )
 

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -183,6 +183,11 @@ class GameInitializer:
         cheese_mode_enabled = current_mode == CHEESE_MODE_NAME
         trail_mode_enabled = current_mode == TRAIL_MODE_NAME
         shrinking_mode_enabled = current_mode == SHRINKING_MODE_NAME
+        speed_boost_mode_enabled = bool(
+            self._settings
+            and hasattr(self._settings, "get")
+            and self._settings.get("enable_speed_boost")
+        )
 
         class GameStateEntity:
             def __init__(self):
@@ -197,6 +202,7 @@ class GameInitializer:
                     cheese_mode_enabled=cheese_mode_enabled,
                     trail_mode_enabled=trail_mode_enabled,
                     shrinking_mode_enabled=shrinking_mode_enabled,
+                    speed_boost_mode_enabled=speed_boost_mode_enabled,
                 )
 
             def get_type(self):
@@ -274,6 +280,7 @@ class GameInitializer:
             cheese_mode=(self._game_mode == CHEESE_MODE_NAME),
             shrinking_mode=(self._game_mode == SHRINKING_MODE_NAME),
             autoplay_mode=(self._game_mode == AUTOPLAY_MODE_NAME),
+            speed_boost_mode=bool(self._settings.get("enable_speed_boost")),
         )
 
     def _create_apple_config(self, world: World) -> None:

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -46,6 +46,7 @@ class GameSettings:
         "speed_increase_rate": "10%",  # Speed increase per apple: 5% or 10%
         "enable_hunger": False,
         "segment_borders": False,  # Dark borders around snake segments
+        "enable_speed_boost": False,  # Temporary speed boost when eating apples
     }
 
     # Settings that are restricted/forced for Autoplay mode
@@ -151,6 +152,13 @@ class GameSettings:
         {
             "key": "electric_walls",
             "label": "Electric walls",
+            "type": "bool",
+            "requires_reset": True,
+            "category": "Gameplay",
+        },
+        {
+            "key": "enable_speed_boost",
+            "label": "Speed boost on apple",
             "type": "bool",
             "requires_reset": True,
             "category": "Gameplay",

--- a/tests/ecs/test_speed_boost_mode.py
+++ b/tests/ecs/test_speed_boost_mode.py
@@ -78,7 +78,9 @@ def create_game_state(speed_boost_mode_enabled=False, game_started=True):
             self.game_state = GameState(
                 speed_boost_mode_enabled=speed_boost_mode_enabled,
                 game_mode=(
-                    "Speed Boost Mode" if speed_boost_mode_enabled else "Classic Snake Game"
+                    "Speed Boost Mode"
+                    if speed_boost_mode_enabled
+                    else "Classic Snake Game"
                 ),
                 game_started=game_started,
             )

--- a/tests/ecs/test_speed_boost_mode.py
+++ b/tests/ecs/test_speed_boost_mode.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Speed Boost Mode tests.
+
+Tests the unique mechanics of Speed Boost Mode:
+- Speed boost activates when eating apple
+- Speed boost timer decrements over time
+- Speed boost expires after duration
+- Speed multiplier is applied during boost
+- No effect in other game modes (regression tests)
+"""
+
+import pytest
+
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.speed_boost import SpeedBoostSystem
+from ecs.systems.movement import MovementSystem
+from ecs.entities.snake import Snake
+from ecs.components.position import Position
+from ecs.components.velocity import Velocity
+from ecs.components.snake_body import SnakeBody
+from ecs.components.interpolation import Interpolation
+from ecs.components.renderable import Renderable
+from ecs.components.input_buffer import InputBuffer
+from ecs.components.game_state import GameState
+from ecs.components.hunger import Hunger
+from ecs.components.speed_boost import SpeedBoost
+from core.types.color import Color
+
+
+@pytest.fixture
+def board():
+    """Create a 10x10 board for testing."""
+    return Board(width=10, height=10, cell_size=30)
+
+
+@pytest.fixture
+def world(board):
+    """Create a world with board."""
+    return World(board)
+
+
+@pytest.fixture
+def speed_boost_system():
+    """Create a SpeedBoostSystem for testing."""
+    return SpeedBoostSystem()
+
+
+@pytest.fixture
+def movement_system():
+    """Create a MovementSystem for testing."""
+    return MovementSystem()
+
+
+def create_game_state(speed_boost_mode_enabled=False, game_started=True):
+    """Helper to create a GameState entity."""
+
+    class GameStateEntity:
+        def __init__(self):
+            self.game_state = GameState(
+                speed_boost_mode_enabled=speed_boost_mode_enabled,
+                game_mode=(
+                    "Speed Boost Mode" if speed_boost_mode_enabled else "Classic Snake Game"
+                ),
+                game_started=game_started,
+            )
+
+        def get_type(self):
+            return None
+
+    return GameStateEntity()
+
+
+def create_snake_at(x, y, dx=1, dy=0, with_speed_boost=True):
+    """Helper to create a snake at a specific position."""
+    speed_boost = SpeedBoost() if with_speed_boost else None
+    return Snake(
+        position=Position(x=x, y=y, prev_x=x, prev_y=y),
+        velocity=Velocity(dx=dx, dy=dy, speed=10.0),
+        body=SnakeBody(segments=[], size=1),
+        interpolation=Interpolation(),
+        renderable=Renderable(shape="square", color=Color(0, 255, 0), size=30),
+        input_buffer=InputBuffer(),
+        hunger=Hunger(current_time=0.0, max_time=0.0),
+        speed_boost=speed_boost,
+    )
+
+
+class TestSpeedBoostComponent:
+    """Test SpeedBoost component functionality."""
+
+    def test_speed_boost_inactive_by_default(self):
+        """Test that SpeedBoost starts inactive."""
+        boost = SpeedBoost()
+        assert boost.active is False
+        assert boost.remaining_time == 0.0
+
+    def test_speed_boost_default_values(self):
+        """Test that SpeedBoost has correct default values."""
+        boost = SpeedBoost()
+        assert boost.multiplier == 2.0
+        assert boost.duration == 3.0
+
+    def test_speed_boost_activate(self):
+        """Test that activate() sets active and resets timer."""
+        boost = SpeedBoost()
+        boost.activate()
+        assert boost.active is True
+        assert boost.remaining_time == boost.duration
+
+    def test_speed_boost_deactivate(self):
+        """Test that deactivate() clears active and timer."""
+        boost = SpeedBoost()
+        boost.activate()
+        boost.deactivate()
+        assert boost.active is False
+        assert boost.remaining_time == 0.0
+
+
+class TestSpeedBoostSystem:
+    """Test SpeedBoostSystem functionality."""
+
+    def test_system_does_nothing_when_mode_disabled(self, world, speed_boost_system):
+        """Test that system does nothing when Speed Boost Mode is disabled."""
+        # Setup: Classic mode (speed_boost_mode_enabled=False)
+        game_state_entity = create_game_state(speed_boost_mode_enabled=False)
+        world.registry.add(game_state_entity)
+
+        # Create snake with active boost
+        snake = create_snake_at(5, 5)
+        snake.speed_boost.activate()
+        world.registry.add(snake)
+
+        # Update with 1 second
+        world.set_dt_ms(1000)
+        speed_boost_system.update(world)
+
+        # Boost should NOT have decremented (mode disabled)
+        assert snake.speed_boost.active is True
+        assert snake.speed_boost.remaining_time == snake.speed_boost.duration
+
+    def test_system_decrements_timer(self, world, speed_boost_system):
+        """Test that system decrements boost timer when mode enabled."""
+        # Setup: Speed Boost Mode enabled
+        game_state_entity = create_game_state(speed_boost_mode_enabled=True)
+        world.registry.add(game_state_entity)
+
+        # Create snake with active boost
+        snake = create_snake_at(5, 5)
+        snake.speed_boost.activate()
+        initial_time = snake.speed_boost.remaining_time
+        world.registry.add(snake)
+
+        # Update with 500ms (0.5 seconds)
+        world.set_dt_ms(500)
+        speed_boost_system.update(world)
+
+        # Timer should have decremented
+        assert snake.speed_boost.active is True
+        assert snake.speed_boost.remaining_time == initial_time - 0.5
+
+    def test_system_deactivates_expired_boost(self, world, speed_boost_system):
+        """Test that system deactivates boost when timer reaches zero."""
+        # Setup
+        game_state_entity = create_game_state(speed_boost_mode_enabled=True)
+        world.registry.add(game_state_entity)
+
+        snake = create_snake_at(5, 5)
+        snake.speed_boost.activate()
+        world.registry.add(snake)
+
+        # Update with time equal to duration (3 seconds = 3000ms)
+        world.set_dt_ms(3000)
+        speed_boost_system.update(world)
+
+        # Boost should be deactivated
+        assert snake.speed_boost.active is False
+        assert snake.speed_boost.remaining_time == 0.0
+
+
+class TestSpeedBoostInMovement:
+    """Test speed boost integration with MovementSystem."""
+
+    def test_speed_multiplier_applied_when_active(self, world, movement_system):
+        """Test that MovementSystem applies speed multiplier when boost active."""
+        # Setup
+        game_state_entity = create_game_state(speed_boost_mode_enabled=True)
+        world.registry.add(game_state_entity)
+
+        snake = create_snake_at(5, 5, dx=1, dy=0)
+        snake.speed_boost.activate()
+        world.registry.add(snake)
+
+        # Base speed is 10.0, with 2x multiplier = 20.0
+        # Move interval = 1000 / 20.0 = 50ms
+        # Update with 50ms should trigger a move
+        world.set_dt_ms(50)
+        movement_system.update(world)
+
+        # Snake should have moved
+        assert snake.position.x == 6 or snake.position.prev_x == 5
+
+    def test_speed_normal_when_boost_inactive(self, world, movement_system):
+        """Test that MovementSystem uses normal speed when boost inactive."""
+        # Setup
+        game_state_entity = create_game_state(speed_boost_mode_enabled=True)
+        world.registry.add(game_state_entity)
+
+        snake = create_snake_at(5, 5, dx=1, dy=0)
+        # Don't activate boost
+        world.registry.add(snake)
+
+        # Base speed is 10.0
+        # Move interval = 1000 / 10.0 = 100ms
+        # Update with 50ms should NOT trigger a move
+        world.set_dt_ms(50)
+        movement_system.update(world)
+
+        # Snake should NOT have moved yet
+        assert snake.position.x == 5
+
+
+class TestSpeedBoostRefresh:
+    """Test speed boost refresh behavior."""
+
+    def test_boost_refresh_resets_timer(self):
+        """Test that activating boost again resets the timer."""
+        boost = SpeedBoost()
+        boost.activate()
+
+        # Simulate some time passing
+        boost.remaining_time = 1.0
+
+        # Activate again (eating another apple)
+        boost.activate()
+
+        # Timer should be reset to full duration
+        assert boost.remaining_time == boost.duration
+
+
+def test_speed_boost_integration(world, speed_boost_system, movement_system):
+    """Integration test: Speed Boost Mode with both systems."""
+    # Setup
+    game_state_entity = create_game_state(speed_boost_mode_enabled=True)
+    world.registry.add(game_state_entity)
+
+    snake = create_snake_at(5, 5, dx=1, dy=0)
+    snake.speed_boost.activate()
+    world.registry.add(snake)
+
+    # Run several update cycles
+    for _ in range(10):
+        world.set_dt_ms(100)
+        movement_system.update(world)
+        speed_boost_system.update(world)
+
+    # After 1 second, boost should still be active (3s duration)
+    assert snake.speed_boost.active is True
+    assert snake.speed_boost.remaining_time == pytest.approx(2.0, rel=0.1)
+
+    # Run until boost expires
+    for _ in range(25):
+        world.set_dt_ms(100)
+        speed_boost_system.update(world)
+
+    # Boost should now be expired
+    assert snake.speed_boost.active is False

--- a/tests/ecs/test_trail_mode.py
+++ b/tests/ecs/test_trail_mode.py
@@ -46,7 +46,6 @@ from ecs.entities.entity import EntityType
 from core.types.color import Color
 
 
-
 @pytest.fixture
 def board():
     """Create a 10x10 board for testing."""
@@ -84,7 +83,9 @@ def create_game_state(trail_mode_enabled=False, game_started=True):
         def __init__(self):
             self.game_state = GameState(
                 trail_mode_enabled=trail_mode_enabled,
-                game_mode=("Trail Mode" if trail_mode_enabled else "Classic Snake Game"),
+                game_mode=(
+                    "Trail Mode" if trail_mode_enabled else "Classic Snake Game"
+                ),
                 game_started=game_started,
             )
 
@@ -110,9 +111,7 @@ def create_snake_at(x, y, dx=1, dy=0):
 class TestTrailModeBasics:
     """Test basic Trail Mode functionality."""
 
-    def test_trail_system_creates_no_obstacles_when_disabled(
-        self, world, trail_system
-    ):
+    def test_trail_system_creates_no_obstacles_when_disabled(self, world, trail_system):
         """Test that trail system does nothing when Trail Mode is disabled."""
         # Setup: Classic mode (trail_mode_enabled=False)
         game_state_entity = create_game_state(trail_mode_enabled=False)
@@ -171,7 +170,7 @@ class TestTrailModeBasics:
         # Verify obstacle created at previous position
         obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
         assert len(obstacles) == 1, "One obstacle should be created"
-        
+
         obstacle = list(obstacles.values())[0]
         assert obstacle.position.x == 5
         assert obstacle.position.y == 5

--- a/tests/ecs/test_trail_mode.py
+++ b/tests/ecs/test_trail_mode.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Trail Mode tests.
+
+Tests the unique mechanics of Trail Mode:
+- Trail obstacles created at previous head positions
+- Trail obstacles persist throughout the game
+- Trail obstacles cause collision/death
+- Classic mode unchanged (regression tests)
+"""
+
+import pytest
+
+from ecs.world import World
+from ecs.board import Board
+from ecs.systems.trail_generation import TrailGenerationSystem
+from ecs.systems.movement import MovementSystem
+from ecs.systems.collision import CollisionSystem
+from ecs.entities.snake import Snake
+from ecs.components.position import Position
+from ecs.components.velocity import Velocity
+from ecs.components.snake_body import SnakeBody
+from ecs.components.interpolation import Interpolation
+from ecs.components.renderable import Renderable
+from ecs.components.input_buffer import InputBuffer
+from ecs.components.game_state import GameState
+from ecs.components.hunger import Hunger
+from ecs.entities.entity import EntityType
+from core.types.color import Color
+
+
+
+@pytest.fixture
+def board():
+    """Create a 10x10 board for testing."""
+    return Board(width=10, height=10, cell_size=30)
+
+
+@pytest.fixture
+def world(board):
+    """Create a world with board."""
+    return World(board)
+
+
+@pytest.fixture
+def trail_system():
+    """Create a TrailGenerationSystem for testing."""
+    return TrailGenerationSystem()
+
+
+@pytest.fixture
+def movement_system():
+    """Create a MovementSystem for testing."""
+    return MovementSystem()
+
+
+@pytest.fixture
+def collision_system():
+    """Create a CollisionSystem for testing."""
+    return CollisionSystem()
+
+
+def create_game_state(trail_mode_enabled=False, game_started=True):
+    """Helper to create a GameState entity."""
+
+    class GameStateEntity:
+        def __init__(self):
+            self.game_state = GameState(
+                trail_mode_enabled=trail_mode_enabled,
+                game_mode=("Trail Mode" if trail_mode_enabled else "Classic Snake Game"),
+                game_started=game_started,
+            )
+
+        def get_type(self):
+            return None
+
+    return GameStateEntity()
+
+
+def create_snake_at(x, y, dx=1, dy=0):
+    """Helper to create a snake at a specific position."""
+    return Snake(
+        position=Position(x=x, y=y, prev_x=x, prev_y=y),
+        velocity=Velocity(dx=dx, dy=dy),
+        body=SnakeBody(segments=[], size=1),
+        interpolation=Interpolation(),
+        renderable=Renderable(shape="square", color=Color(0, 255, 0), size=30),
+        input_buffer=InputBuffer(),
+        hunger=Hunger(current_time=0.0, max_time=0.0),
+    )
+
+
+class TestTrailModeBasics:
+    """Test basic Trail Mode functionality."""
+
+    def test_trail_system_creates_no_obstacles_when_disabled(
+        self, world, trail_system
+    ):
+        """Test that trail system does nothing when Trail Mode is disabled."""
+        # Setup: Classic mode (trail_mode_enabled=False)
+        game_state_entity = create_game_state(trail_mode_enabled=False)
+        world.registry.add(game_state_entity)
+
+        # Create snake
+        snake = create_snake_at(5, 5)
+        world.registry.add(snake)
+
+        # Update trail system
+        world.set_dt_ms(1000)
+        trail_system.update(world)
+
+        # Move snake
+        snake.position.prev_x = snake.position.x
+        snake.position.prev_y = snake.position.y
+        snake.position.x = 6
+        snake.position.y = 5
+
+        # Update trail system again
+        trail_system.update(world)
+
+        # Verify no trail obstacles created
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        assert len(obstacles) == 0, "No obstacles should be created in Classic mode"
+
+    def test_trail_system_creates_obstacle_at_previous_position(
+        self, world, trail_system
+    ):
+        """Test that trail system creates obstacles where the snake was."""
+        # Setup: Trail mode enabled
+        game_state_entity = create_game_state(trail_mode_enabled=True)
+        world.registry.add(game_state_entity)
+
+        # Create snake at (5, 5)
+        snake = create_snake_at(5, 5)
+        world.registry.add(snake)
+
+        # First update - establish initial position
+        world.set_dt_ms(1000)
+        trail_system.update(world)
+
+        # No obstacles yet (snake hasn't moved)
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        assert len(obstacles) == 0
+
+        # Move snake to (6, 5)
+        snake.position.prev_x = snake.position.x
+        snake.position.prev_y = snake.position.y
+        snake.position.x = 6
+        snake.position.y = 5
+
+        # Update trail system - should create obstacle at (5, 5)
+        trail_system.update(world)
+
+        # Verify obstacle created at previous position
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        assert len(obstacles) == 1, "One obstacle should be created"
+        
+        obstacle = list(obstacles.values())[0]
+        assert obstacle.position.x == 5
+        assert obstacle.position.y == 5
+
+    def test_trail_obstacles_persist(self, world, trail_system):
+        """Test that trail obstacles remain after being created."""
+        # Setup
+        game_state_entity = create_game_state(trail_mode_enabled=True)
+        world.registry.add(game_state_entity)
+
+        snake = create_snake_at(5, 5)
+        world.registry.add(snake)
+
+        world.set_dt_ms(1000)
+        trail_system.update(world)
+
+        # Move snake multiple times
+        positions = [(6, 5), (7, 5), (8, 5)]
+        for new_x, new_y in positions:
+            snake.position.prev_x = snake.position.x
+            snake.position.prev_y = snake.position.y
+            snake.position.x = new_x
+            snake.position.y = new_y
+            trail_system.update(world)
+
+        # Verify all obstacles persist
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        assert len(obstacles) == 3, "All trail obstacles should persist"
+
+    def test_no_duplicate_trail_obstacles(self, world, trail_system):
+        """Test that trail system doesn't create duplicate obstacles at same position."""
+        # Setup
+        game_state_entity = create_game_state(trail_mode_enabled=True)
+        world.registry.add(game_state_entity)
+
+        snake = create_snake_at(5, 5, dx=1, dy=0)
+        world.registry.add(snake)
+
+        world.set_dt_ms(1000)
+        trail_system.update(world)
+
+        # Move snake forward then back to create potential duplicate
+        snake.position.prev_x, snake.position.prev_y = 5, 5
+        snake.position.x, snake.position.y = 6, 5
+        trail_system.update(world)
+
+        snake.position.prev_x, snake.position.prev_y = 6, 5
+        snake.position.x, snake.position.y = 5, 5
+        trail_system.update(world)
+
+        # Count obstacles at (5, 5)
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        obstacles_at_5_5 = sum(
+            1
+            for obs in obstacles.values()
+            if obs.position.x == 5 and obs.position.y == 5
+        )
+        assert obstacles_at_5_5 <= 1, "Should not create duplicate trail obstacles"
+
+
+class TestTrailModeCollision:
+    """Test Trail Mode collision behavior."""
+
+    def test_collision_with_trail_obstacle_kills_snake(
+        self, world, trail_system, collision_system
+    ):
+        """Test that colliding with trail obstacle causes death."""
+        # Setup
+        game_state_entity = create_game_state(trail_mode_enabled=True)
+        world.registry.add(game_state_entity)
+
+        snake = create_snake_at(5, 5)
+        world.registry.add(snake)
+
+        world.set_dt_ms(1000)
+        trail_system.update(world)
+
+        # Create trail at (6, 5)
+        snake.position.prev_x, snake.position.prev_y = 5, 5
+        snake.position.x, snake.position.y = 6, 5
+        trail_system.update(world)
+
+        # Move away
+        snake.position.prev_x, snake.position.prev_y = 6, 5
+        snake.position.x, snake.position.y = 7, 5
+        trail_system.update(world)
+
+        # Verify trail exists at (6, 5)
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        assert len(obstacles) >= 1
+
+        # Move back into trail obstacle at (6, 5)
+        snake.position.prev_x, snake.position.prev_y = 7, 5
+        snake.position.x, snake.position.y = 6, 5
+
+        # Check collision
+        collision_detected = collision_system._check_obstacle_collision(world)
+        assert collision_detected, "Collision with trail obstacle should be detected"
+
+
+def test_trail_mode_integration(world, trail_system, movement_system):
+    """Integration test: Trail Mode with MovementSystem."""
+    # Setup
+    game_state_entity = create_game_state(trail_mode_enabled=True)
+    world.registry.add(game_state_entity)
+
+    snake = create_snake_at(5, 5, dx=1, dy=0)
+    world.registry.add(snake)
+
+    world.set_dt_ms(1000)
+
+    # Initial update
+    trail_system.update(world)
+    initial_obstacles = len(world.registry.query_by_type(EntityType.OBSTACLE))
+
+    # Move and create trail
+    movement_system.update(world)
+    trail_system.update(world)
+
+    # Verify trail obstacle created after movement
+    obstacles_after_move = len(world.registry.query_by_type(EntityType.OBSTACLE))
+    assert (
+        obstacles_after_move > initial_obstacles
+    ), "Trail obstacle should be created after movement"


### PR DESCRIPTION
Implements Speed Boost Mode where eating apples grants temporary 2x speed boost.
## Changes
- **New component**: `src/ecs/components/speed_boost.py` - Tracks boost state and timer
- **New system**: `src/ecs/systems/speed_boost.py` - Manages boost lifecycle
- **Modified**: `src/ecs/components/game_state.py` - Added `speed_boost_mode_enabled` flag
- **Modified**: `src/game/game_modes_registry.py` - Registered new mode
- **Modified**: `src/ecs/systems/movement.py` - Applies speed multiplier when boosted
- **Modified**: `src/game/scenes/gameplay.py` - Integrated SpeedBoostSystem
- **New tests**: `tests/ecs/test_speed_boost_mode.py`

Closes #451 