### PR TITLE
[FEAT] You Win Screen For All Game Modes

### DIFF
--- a/scripts/preview_win_screens.py
+++ b/scripts/preview_win_screens.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Preview all victory screens for testing purposes.
+
+Run with: .venv/bin/python scripts/preview_win_screens.py
+"""
+
+import pygame
+import sys
+import os
+
+# Add src to path - must be before imports
+src_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src")
+sys.path.insert(0, src_path)
+
+from game.constants import (  # noqa: E402
+    ARENA_PRIMARY_COLOR,
+    VICTORY_TITLE_COLOR,
+    VICTORY_MESSAGE_COLOR,
+    VICTORY_HIGHLIGHT_COLOR,
+    VICTORY_HIGH_SCORE_COLOR,
+    GAME_OVER_MESSAGE_COLOR,
+    GAME_OVER_HIGHLIGHT_COLOR,
+)
+from core.types.color import Color  # noqa: E402
+
+
+# Win messages to preview (matching what each game mode would use)
+WIN_MESSAGES = [
+    ("Shrinking Mode", "Win: Fully Shrunk!"),
+    ("AutoPlay", "Win: Board Complete!"),
+    ("Box Mode", "Win: All Boxes Cleared!"),
+    ("Classic (fill board)", "Win: Perfect Game!"),
+    ("Default/Other", "Win:"),  # Tests the fallback message
+    ("Game Over (loss)", "Hit wall"),  # Compare with regular game over
+]
+
+
+def main():
+    pygame.init()
+
+    width, height = 960, 800
+    screen = pygame.display.set_mode((width, height))
+    pygame.display.set_caption("Victory Screen Preview - Use LEFT/RIGHT arrows")
+
+    current_index = 0
+    clock = pygame.time.Clock()
+
+    font_path = "assets/font/GetVoIP-Grotesque.ttf"
+    try:
+        big_font = pygame.font.Font(font_path, 80)
+        medium_font = pygame.font.Font(font_path, 40)
+        small_font = pygame.font.Font(font_path, 24)
+    except Exception:
+        big_font = pygame.font.Font(None, 80)
+        medium_font = pygame.font.Font(None, 40)
+        small_font = pygame.font.Font(None, 24)
+
+    print("\n=== Victory Screen Preview ===")
+    print("Press LEFT/RIGHT to cycle through win screens")
+    print("Press ESC or Q to quit\n")
+    print(f"Showing: {WIN_MESSAGES[current_index][0]}")
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_ESCAPE, pygame.K_q):
+                    running = False
+                elif event.key == pygame.K_RIGHT:
+                    current_index = (current_index + 1) % len(WIN_MESSAGES)
+                    print(f"Showing: {WIN_MESSAGES[current_index][0]}")
+                elif event.key == pygame.K_LEFT:
+                    current_index = (current_index - 1) % len(WIN_MESSAGES)
+                    print(f"Showing: {WIN_MESSAGES[current_index][0]}")
+
+        mode_name, death_reason = WIN_MESSAGES[current_index]
+        is_victory = death_reason.startswith("Win:")
+
+        # Get victory message
+        if is_victory and len(death_reason) > 5:
+            victory_message = death_reason[5:].strip()
+        else:
+            victory_message = "You completed the game!"
+
+        # Clear screen
+        screen.fill(Color.from_hex(ARENA_PRIMARY_COLOR).to_tuple())
+
+        # Choose colors based on win/loss
+        if is_victory:
+            title_color = VICTORY_TITLE_COLOR
+            message_color = VICTORY_MESSAGE_COLOR
+            highlight_color = VICTORY_HIGHLIGHT_COLOR
+            high_score_color = VICTORY_HIGH_SCORE_COLOR
+            title_text = "You Win!"
+        else:
+            title_color = GAME_OVER_MESSAGE_COLOR
+            message_color = GAME_OVER_MESSAGE_COLOR
+            highlight_color = GAME_OVER_HIGHLIGHT_COLOR
+            high_score_color = (255, 69, 0)
+            title_text = "Game Over"
+
+        # Render title
+        title_surface = big_font.render(title_text, True, title_color)
+        title_rect = title_surface.get_rect(center=(width // 2, height // 4))
+        screen.blit(title_surface, title_rect)
+
+        # Render victory message (only for wins)
+        y_offset = height // 2.5
+        if is_victory:
+            msg_surface = medium_font.render(victory_message, True, message_color)
+            msg_rect = msg_surface.get_rect(center=(width // 2, y_offset))
+            screen.blit(msg_surface, msg_rect)
+            y_offset += 60
+
+        # Render "NEW HIGH SCORE!"
+        hs_surface = medium_font.render("* NEW HIGH SCORE! *", True, high_score_color)
+        hs_rect = hs_surface.get_rect(center=(width // 2, y_offset))
+        screen.blit(hs_surface, hs_rect)
+        y_offset += 60
+
+        # Render score
+        score_surface = medium_font.render("Score: 100", True, highlight_color)
+        score_rect = score_surface.get_rect(center=(width // 2, y_offset))
+        screen.blit(score_surface, score_rect)
+
+        # Draw mode label at bottom
+        label = small_font.render(
+            f"[LEFT/RIGHT] Mode: {mode_name}  |  death_reason='{death_reason}'",
+            True,
+            (100, 100, 100),
+        )
+        screen.blit(label, (20, height - 40))
+
+        pygame.display.flip()
+        clock.tick(30)
+
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preview_win_screens.py
+++ b/scripts/preview_win_screens.py
@@ -20,6 +20,7 @@ from game.constants import (  # noqa: E402
     VICTORY_HIGH_SCORE_COLOR,
     GAME_OVER_MESSAGE_COLOR,
     GAME_OVER_HIGHLIGHT_COLOR,
+    GAME_OVER_HIGH_SCORE_COLOR,
 )
 from core.types.color import Color  # noqa: E402
 
@@ -98,7 +99,7 @@ def main():
             title_color = GAME_OVER_MESSAGE_COLOR
             message_color = GAME_OVER_MESSAGE_COLOR
             highlight_color = GAME_OVER_HIGHLIGHT_COLOR
-            high_score_color = (255, 69, 0)
+            high_score_color = GAME_OVER_HIGH_SCORE_COLOR
             title_text = "Game Over"
 
         # Render title

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+# Requirements for running preview scripts
+# Install with: pip install -r scripts/requirements.txt
+pygame>=2.6.0
+platformdirs>=4.0.0

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -818,6 +818,15 @@ class CollisionSystem(BaseSystem):
                         # remove eaten apple
                         world.registry.remove(entity_id)
 
+                    # Check for board-fill victory (Classic and other modes)
+                    # Skip for shrinking mode (handled separately) and AutoPlay (has its own check)
+                    game_state = self._get_game_state(world)
+                    if game_state and not getattr(
+                        game_state, "shrinking_mode_enabled", False
+                    ):
+                        if self._check_board_fill_victory(world):
+                            return  # Victory triggered, stop processing
+
                     break  # only eat one apple per frame
 
     def _handle_death(self, world: World, reason: str) -> None:
@@ -829,6 +838,31 @@ class CollisionSystem(BaseSystem):
             self._game_over_service.handle_death(world, reason)
         else:
             print(f"☠️ DEATH CAUSE: {reason} (Service missing)")
+
+    def _check_board_fill_victory(self, world: World) -> bool:
+        """Check if snake has filled the entire board (victory for Classic mode).
+
+        Returns True if victory was triggered, False otherwise.
+        """
+        snake = self._get_snake_entity(world)
+        if not snake or not hasattr(snake, "body"):
+            return False
+
+        # Calculate snake length (head + body segments)
+        snake_length = 1 + len(snake.body.segments)
+
+        # Get board size
+        board_size = world.board.width * world.board.height
+
+        # Victory when snake fills entire board
+        if snake_length >= board_size:
+            if self._game_over_service:
+                self._game_over_service.handle_victory(world, "Perfect Game!")
+            else:
+                print("🏆 VICTORY! Snake filled the board!")
+            return True
+
+        return False
 
     def _should_swap_head_and_tail(self, world: World) -> bool:
         """Determine if apple effects should swap the snake head and tail."""

--- a/src/game/constants.py
+++ b/src/game/constants.py
@@ -40,6 +40,12 @@ GAME_OVER_NEW_SCORE_COLOR = (
 GAME_OVER_HIGH_SCORE_COLOR = (255, 69, 0)  # Red-orange for "NEW HIGH SCORE!" message
 GAME_OVER_TIMESTAMP_COLOR = (80, 80, 80)  # Dark gray for timestamps
 GAME_OVER_TIMESTAMP_HIGHLIGHT_COLOR = (180, 160, 0)  # Gold-ish for new score timestamp
+
+# Victory screen colors (green/gold theme)
+VICTORY_TITLE_COLOR = (50, 205, 50)  # Lime green for "You Win!"
+VICTORY_MESSAGE_COLOR = (144, 238, 144)  # Light green for victory message
+VICTORY_HIGHLIGHT_COLOR = (255, 215, 0)  # Gold for score
+VICTORY_HIGH_SCORE_COLOR = (0, 255, 127)  # Spring green for "NEW HIGH SCORE!"
 #
 WINDOW_TITLE = "Naja"  # Window title.
 CLOCK_TICKS = 4  # How fast the snake moves.

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -36,6 +36,10 @@ from game.constants import (
     GAME_OVER_HIGH_SCORE_COLOR,
     GAME_OVER_TIMESTAMP_COLOR,
     GAME_OVER_TIMESTAMP_HIGHLIGHT_COLOR,
+    VICTORY_TITLE_COLOR,
+    VICTORY_MESSAGE_COLOR,
+    VICTORY_HIGHLIGHT_COLOR,
+    VICTORY_HIGH_SCORE_COLOR,
 )
 from game.scoreboard import Scoreboard, MAX_SCOREBOARD_ENTRIES
 from game.settings import GameSettings
@@ -85,7 +89,23 @@ class GameOverScene(BaseScene):
         self._current_score = 0
         self._is_new_high_score = False
         self._new_score_timestamp = None
-        self._is_victory = False
+
+    @property
+    def _is_victory(self) -> bool:
+        """Check if this is a victory (win) instead of a death (loss)."""
+        return self._death_reason.startswith("Win:")
+
+    @property
+    def _victory_message(self) -> str:
+        """Get the victory message to display based on death_reason.
+
+        Extracts the message after 'Win: ' prefix, or returns a default.
+        This allows new game modes to automatically use their custom message
+        by setting death_reason to 'Win: <their message>'.
+        """
+        if self._is_victory and len(self._death_reason) > 5:
+            return self._death_reason[5:].strip()  # Remove 'Win: ' prefix
+        return "You completed the game!"  # Default fallback for others
 
     def update(self, dt_ms: float) -> Optional[str]:
         """Update game over logic.
@@ -139,39 +159,43 @@ class GameOverScene(BaseScene):
                 small_font = pygame.font.Font(None, small_font_size)
                 tiny_font = pygame.font.Font(None, tiny_font_size)
 
-            # Use color constants from game.constants
-            message_color = GAME_OVER_MESSAGE_COLOR
-            highlight_color = GAME_OVER_HIGHLIGHT_COLOR
-            new_score_color = GAME_OVER_NEW_SCORE_COLOR
-            high_score_color = GAME_OVER_HIGH_SCORE_COLOR
-
-            # Victory colors (green/gold theme)
-            victory_color = (0, 255, 100)  # Bright green
-            victory_highlight = (255, 215, 0)  # Gold
-
-            # "Game Over" or "You Win!" text centered
+            # Use victory or game over colors based on win/loss
             if self._is_victory:
-                title_text = big_font.render("You Win!", True, victory_color)
+                title_color = VICTORY_TITLE_COLOR
+                message_color = VICTORY_MESSAGE_COLOR
+                highlight_color = VICTORY_HIGHLIGHT_COLOR
+                high_score_color = VICTORY_HIGH_SCORE_COLOR
+                new_score_color = VICTORY_HIGHLIGHT_COLOR
+                title_text = "You Win!"
             else:
-                title_text = big_font.render("Game Over", True, message_color)
-            title_rect = title_text.get_rect(
+                title_color = GAME_OVER_MESSAGE_COLOR
+                message_color = GAME_OVER_MESSAGE_COLOR
+                highlight_color = GAME_OVER_HIGHLIGHT_COLOR
+                high_score_color = GAME_OVER_HIGH_SCORE_COLOR
+                new_score_color = GAME_OVER_NEW_SCORE_COLOR
+                title_text = "Game Over"
+
+
+            # Title text (either "You Win!" or "Game Over") centered
+            title_surface = big_font.render(title_text, True, title_color)
+            title_rect = title_surface.get_rect(
                 center=(self._width // 2, self._height / 5)
             )
-            self._renderer.blit(title_text, title_rect)
+            self._renderer.blit(title_surface, title_rect)
 
-            # Victory subtitle
+            # Display victory message or "NEW HIGH SCORE!" below title
+            y_offset = self._height / 3.5
             if self._is_victory:
-                subtitle = medium_font.render(
-                    "🏆 Perfect Game! 🏆", True, victory_highlight
+                # Show victory message (e.g., "Fully Shrunk!", "Board Complete!")
+                victory_text = medium_font.render(
+                    self._victory_message, True, message_color
                 )
-                subtitle_rect = subtitle.get_rect(
-                    center=(self._width // 2, self._height / 5 + 70)
+                victory_rect = victory_text.get_rect(
+                    center=(self._width // 2, y_offset)
                 )
-                self._renderer.blit(subtitle, subtitle_rect)
+                self._renderer.blit(victory_text, victory_rect)
+                y_offset += 50
 
-            # Display "NEW HIGH SCORE!" if applicable
-            # Start lower when victory subtitle is displayed
-            y_offset = self._height / 2.8 if self._is_victory else self._height / 3.5
             if self._is_new_high_score:
                 high_score_text = medium_font.render(
                     "* NEW HIGH SCORE! *", True, high_score_color

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -175,7 +175,6 @@ class GameOverScene(BaseScene):
                 new_score_color = GAME_OVER_NEW_SCORE_COLOR
                 title_text = "Game Over"
 
-
             # Title text (either "You Win!" or "Game Over") centered
             title_surface = big_font.render(title_text, True, title_color)
             title_rect = title_surface.get_rect(
@@ -339,8 +338,9 @@ class GameOverScene(BaseScene):
                 if hasattr(entity, "game_state"):
                     self._current_score = entity.game_state.final_score
                     self._gamemode = entity.game_state.game_mode
-                    # Check if this is a victory
-                    self._is_victory = entity.game_state.death_reason == "Victory"
+                    # Update death_reason from world if not already set
+                    if not self._death_reason and entity.game_state.death_reason:
+                        self._death_reason = entity.game_state.death_reason
 
         # Check if this is a new high score and capture timestamp
         # Note: The score has already been added to the scoreboard by ScoringSystem

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -338,8 +338,9 @@ class GameOverScene(BaseScene):
                 if hasattr(entity, "game_state"):
                     self._current_score = entity.game_state.final_score
                     self._gamemode = entity.game_state.game_mode
-                    # Update death_reason from world if not already set
-                    if not self._death_reason and entity.game_state.death_reason:
+                    # Always update death_reason from world state
+                    # (must reset each time, not check if empty)
+                    if entity.game_state.death_reason:
                         self._death_reason = entity.game_state.death_reason
 
         # Check if this is a new high score and capture timestamp

--- a/src/game/services/game_over_service.py
+++ b/src/game/services/game_over_service.py
@@ -80,17 +80,20 @@ class GameOverService:
 
         print(f"☠️ DEATH CAUSE: {reason}")
 
-    def handle_victory(self, world: World) -> None:
-        """Handle snake victory (filled the entire board).
+    def handle_victory(
+        self, world: World, win_message: str = "Board Complete!"
+    ) -> None:
+        """Handle snake victory.
 
         Similar to handle_death but with victory-specific behavior:
         1. Save final score
         2. Mark snake as "alive" (won, not dead)
         3. Play victory sound
-        4. Update GameState with "Victory" reason
+        4. Update GameState with victory reason
 
         Args:
             world: ECS world
+            win_message: Victory message to display (without "Win:" prefix)
         """
         # Get current score and save to scoreboard
         current_score = 0
@@ -112,11 +115,11 @@ class GameOverService:
         game_state = self._get_game_state(world)
         if game_state:
             game_state.game_over = True
-            game_state.death_reason = "Victory"
+            game_state.death_reason = f"Win: {win_message}"
             game_state.next_scene = "game_over"
             game_state.final_score = current_score
 
-        print("🏆 VICTORY! Snake filled the entire board!")
+        print(f"🏆 VICTORY! {win_message}")
 
     def _get_snake_entity(self, world: World):
         """Helper to find snake entity."""


### PR DESCRIPTION
### Summary
Implements a dynamic "You Win!" screen that displays mode-specific victory messages when game modes are completed successfully.

### Changes
- **Victory Screen Logic**: `GameOverScene` now detects win conditions via `"Win:"` prefix in `death_reason`
- **Victory Colors**: Added green/gold color scheme for wins (vs gray/red for losses)
- **Mode-Specific Messages**: Each game mode can define its own victory message
- **Win Conditions**: Added board-fill victory detection for Classic and other modes
- **Flexible Victory API**: `handle_victory(world, win_message)` now accepts custom messages
- **Preview Tool**: Added `scripts/preview_win_screens.py` to test all victory/game over screens without playing

### Win Conditions by Mode
| Mode | Win Condition | Message |
|------|--------------|---------|
| AutoPlay | Fill entire board | "Board Complete!" |
| Shrinking | Shrink to head only | "shrunk to head" |
| Classic | Fill entire board | "Perfect Game!" |
| Other modes | Fill entire board | "Perfect Game!" |

### Testing
Run the preview tool:
```bash
.venv/bin/python scripts/preview_win_screens.py
```
Use ← → arrows to cycle through screens, ESC to quit.

<img width="963" height="828" alt="Screenshot 2025-12-05 at 19 46 50" src="https://github.com/user-attachments/assets/d30b5eb3-696d-4c13-9f4d-7af0649d114f" />
<img width="962" height="827" alt="Screenshot 2025-12-05 at 19 46 40" src="https://github.com/user-attachments/assets/88464432-3a04-4179-a851-316d0503fd12" />
<img width="962" height="831" alt="Screenshot 2025-12-05 at 19 46 33" src="https://github.com/user-attachments/assets/a56ae20b-1fcc-4a22-abd4-6e55ac1a27ea" />
<img width="962" height="828" alt="Screenshot 2025-12-05 at 19 47 13" src="https://github.com/user-attachments/assets/fec33fdd-0542-4771-823a-09c386265dae" />
<img width="964" height="830" alt="Screenshot 2025-12-05 at 19 47 10" src="https://github.com/user-attachments/assets/4c083d93-5927-4973-b6c0-9bf425c81e96" />
<img width="962" height="828" alt="Screenshot 2025-12-05 at 19 46 56" src="https://github.com/user-attachments/assets/71857d98-bd30-41ea-9e70-e76185305948" />