### PR TITLE
Feat: Add Game Mode section to settings (in menu and in pause menu)

### DIFF
--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -302,7 +302,9 @@ class InputSystem(BaseSystem):
         menu_fields = self._settings.get_in_game_menu_fields()
         # get visible fields (respecting section collapse state)
         if self._overlay_render_system:
-            visible_fields = self._overlay_render_system._get_visible_fields(menu_fields)
+            visible_fields = self._overlay_render_system._get_visible_fields(
+                menu_fields
+            )
         else:
             visible_fields = menu_fields
         total_items = len(visible_fields) + 1  # +1 for "Return to Menu" option
@@ -322,7 +324,10 @@ class InputSystem(BaseSystem):
             elif game_state.settings_selected_index < len(visible_fields):
                 # check if this is a section header
                 current_field = visible_fields[game_state.settings_selected_index]
-                if current_field.get("type") == "section" and self._overlay_render_system:
+                if (
+                    current_field.get("type") == "section"
+                    and self._overlay_render_system
+                ):
                     # toggle section
                     self._overlay_render_system.toggle_section(current_field["key"])
                 else:

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -53,6 +53,7 @@ class InputSystem(BaseSystem):
         pygame_adapter: Optional[Any] = None,
         settings: Optional[Any] = None,
         game_mode: str = "Classic Snake Game",
+        overlay_render_system: Optional[Any] = None,
     ):
         """Initialize the InputSystem.
 
@@ -60,9 +61,11 @@ class InputSystem(BaseSystem):
             pygame_adapter: Pygame IO adapter for reading events
             settings: Game settings for palette randomization
             game_mode: Current game mode
+            overlay_render_system: OverlayRenderSystem for section toggling
         """
         self._pygame_adapter = pygame_adapter
         self._settings = settings
+        self._overlay_render_system = overlay_render_system
         self._game_mode = game_mode
 
     def update(self, world: World) -> None:
@@ -297,8 +300,13 @@ class InputSystem(BaseSystem):
 
         # use only in-game adjustable fields (no reset required)
         menu_fields = self._settings.get_in_game_menu_fields()
-        total_items = len(menu_fields) + 1  # +1 for "Return to Menu" option
-        return_to_menu_index = len(menu_fields)  # last item
+        # get visible fields (respecting section collapse state)
+        if self._overlay_render_system:
+            visible_fields = self._overlay_render_system._get_visible_fields(menu_fields)
+        else:
+            visible_fields = menu_fields
+        total_items = len(visible_fields) + 1  # +1 for "Return to Menu" option
+        return_to_menu_index = len(visible_fields)  # last item
 
         # handle ESC to close settings
         if key == pygame.K_ESCAPE:
@@ -311,6 +319,16 @@ class InputSystem(BaseSystem):
                 game_state.settings_menu_open = False
                 game_state.paused = False
                 game_state.next_scene = "menu"
+            elif game_state.settings_selected_index < len(visible_fields):
+                # check if this is a section header
+                current_field = visible_fields[game_state.settings_selected_index]
+                if current_field.get("type") == "section" and self._overlay_render_system:
+                    # toggle section
+                    self._overlay_render_system.toggle_section(current_field["key"])
+                else:
+                    # close settings and resume game
+                    game_state.settings_menu_open = False
+                    game_state.paused = False
             else:
                 # close settings and resume game
                 game_state.settings_menu_open = False

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -249,7 +249,11 @@ class OverlayRenderSystem(BaseSystem):
             is_section = f.get("type") == "section"
 
             # Draw category header if this is a new category (but not for sections or section children)
-            if not is_section and not is_section_child and f.get("category") != current_category:
+            if (
+                not is_section
+                and not is_section_child
+                and f.get("category") != current_category
+            ):
                 current_category = f.get("category", "Other")
 
                 # Add spacing before category (except first)
@@ -297,7 +301,9 @@ class OverlayRenderSystem(BaseSystem):
                     # Calculate current grid size for display
                     current_grid_size = 20
                     if self._config:
-                        desired_cells = max(10, int(self._settings.get("cells_per_side")))
+                        desired_cells = max(
+                            10, int(self._settings.get("cells_per_side"))
+                        )
                         current_grid_size = self._config.get_optimal_grid_size(
                             desired_cells
                         )

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -54,6 +54,43 @@ class OverlayRenderSystem(BaseSystem):
         self._renderer = renderer
         self._settings = settings
         self._config = config
+        # track which sections are collapsed
+        self._collapsed_sections = set()
+        # initialize collapsed sections from field definitions (only once)
+        if self._settings:
+            for field in self._settings.MENU_FIELDS:
+                if field.get("type") == "section" and field.get("collapsed", False):
+                    self._collapsed_sections.add(field["key"])
+
+    def _get_visible_fields(self, all_fields: list) -> list:
+        """Get only the fields that should be visible based on section collapse state.
+
+        Returns:
+            List of visible fields
+        """
+        visible = []
+        for field in all_fields:
+            # section headers are always visible
+            if field.get("type") == "section":
+                visible.append(field)
+            # regular fields are visible if they don't have a parent section,
+            # or if their parent section is not collapsed
+            else:
+                parent = field.get("parent_section")
+                if not parent or parent not in self._collapsed_sections:
+                    visible.append(field)
+        return visible
+
+    def toggle_section(self, section_key: str) -> None:
+        """Toggle a section's collapsed state.
+
+        Args:
+            section_key: Key of the section to toggle
+        """
+        if section_key in self._collapsed_sections:
+            self._collapsed_sections.remove(section_key)
+        else:
+            self._collapsed_sections.add(section_key)
 
     def draw_pause_overlay(self, surface_width: int, surface_height: int) -> None:
         """Draw pause overlay with semi-transparent background and text.
@@ -181,7 +218,9 @@ class OverlayRenderSystem(BaseSystem):
 
         # Get in-game adjustable settings
         menu_fields = self._settings.get_in_game_menu_fields()
-        return_to_menu_index = len(menu_fields)
+        # get visible fields (respecting section collapse state)
+        visible_fields = self._get_visible_fields(menu_fields)
+        return_to_menu_index = len(visible_fields)
 
         # Calculate available height for content
         content_start_y = padding_y
@@ -190,20 +229,27 @@ class OverlayRenderSystem(BaseSystem):
         # Fonts
         item_font_size = int(surface_width / 32)
         category_font_size = int(surface_width / 32)
+        section_font_size = int(surface_width / 28)
         try:
             item_font = pygame.font.Font(font_path, item_font_size)
             category_font = pygame.font.Font(font_path, category_font_size)
+            section_font = pygame.font.Font(font_path, section_font_size)
         except Exception:
             item_font = pygame.font.Font(None, item_font_size)
             category_font = pygame.font.Font(None, category_font_size)
+            section_font = pygame.font.Font(None, section_font_size)
 
         current_y = padding_y - scroll_offset
         current_category = None
 
         # Draw settings grouped by category
-        for field_i, f in enumerate(menu_fields):
-            # Draw category header if this is a new category
-            if f.get("category") != current_category:
+        for field_i, f in enumerate(visible_fields):
+            # skip category headers for section headers and their children
+            is_section_child = f.get("parent_section") is not None
+            is_section = f.get("type") == "section"
+
+            # Draw category header if this is a new category (but not for sections or section children)
+            if not is_section and not is_section_child and f.get("category") != current_category:
                 current_category = f.get("category", "Other")
 
                 # Add spacing before category (except first)
@@ -226,36 +272,56 @@ class OverlayRenderSystem(BaseSystem):
 
             # Draw setting field only if visible
             if content_start_y - row_h <= current_y <= content_end_y:
-                val = self._settings.get(f["key"])
+                # handle section headers specially
+                if f.get("type") == "section":
+                    # section headers get a collapse indicator
+                    is_expanded = f["key"] not in self._collapsed_sections
+                    indicator = "v" if is_expanded else ">"
+                    label_text = f"{indicator} {f['label']}"
 
-                # Calculate current grid size for display
-                current_grid_size = 20
-                if self._config:
-                    desired_cells = max(10, int(self._settings.get("cells_per_side")))
-                    current_grid_size = self._config.get_optimal_grid_size(
-                        desired_cells
+                    # make section headers slightly larger
+                    text_color = (
+                        Color.from_hex(constants.SCORE_COLOR).to_tuple()
+                        if field_i == selected_index
+                        else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
+                    )
+                    text = section_font.render(label_text, True, text_color)
+                    rect = text.get_rect()
+                    rect.left = left_margin - category_indent
+                    rect.top = current_y
+                    self._renderer.blit(text, rect)
+                else:
+                    # regular fields
+                    val = self._settings.get(f["key"])
+
+                    # Calculate current grid size for display
+                    current_grid_size = 20
+                    if self._config:
+                        desired_cells = max(10, int(self._settings.get("cells_per_side")))
+                        current_grid_size = self._config.get_optimal_grid_size(
+                            desired_cells
+                        )
+
+                    formatted_val = self._settings.format_setting_value(
+                        f,
+                        val,
+                        surface_width,
+                        current_grid_size,
                     )
 
-                formatted_val = self._settings.format_setting_value(
-                    f,
-                    val,
-                    surface_width,
-                    current_grid_size,
-                )
-
-                # Highlight selected item
-                text_color = (
-                    Color.from_hex(constants.SCORE_COLOR).to_tuple()
-                    if field_i == selected_index
-                    else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
-                )
-                text = item_font.render(
-                    f"{f['label']}: {formatted_val}", True, text_color
-                )
-                rect = text.get_rect()
-                rect.left = left_margin
-                rect.top = current_y
-                self._renderer.blit(text, rect)
+                    # Highlight selected item
+                    text_color = (
+                        Color.from_hex(constants.SCORE_COLOR).to_tuple()
+                        if field_i == selected_index
+                        else Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
+                    )
+                    text = item_font.render(
+                        f"{f['label']}: {formatted_val}", True, text_color
+                    )
+                    rect = text.get_rect()
+                    rect.left = left_margin
+                    rect.top = current_y
+                    self._renderer.blit(text, rect)
 
             current_y += row_h
 

--- a/src/ecs/systems/ui/settings_handler.py
+++ b/src/ecs/systems/ui/settings_handler.py
@@ -61,6 +61,53 @@ class SettingsHandler:
         """
         self._renderer = renderer
         self._assets = assets
+        # track which sections are collapsed
+        self._collapsed_sections = set()
+        # note: initialization will happen in run_settings_menu when we have access to settings
+
+    def _initialize_collapsed_sections(self, all_fields: list[dict]) -> None:
+        """Initialize collapsed sections from field definitions (only once).
+
+        Args:
+            all_fields: All menu fields
+        """
+        if not self._collapsed_sections:  # only initialize if empty
+            for field in all_fields:
+                if field["type"] == "section" and field.get("collapsed", False):
+                    self._collapsed_sections.add(field["key"])
+
+    def _get_visible_fields(self, all_fields: list[dict]) -> list[dict]:
+        """Get only the fields that should be visible based on section collapse state.
+
+        Args:
+            all_fields: All menu fields
+
+        Returns:
+            List of visible fields
+        """
+        visible = []
+        for field in all_fields:
+            # section headers are always visible
+            if field["type"] == "section":
+                visible.append(field)
+            # regular fields are visible if they don't have a parent section,
+            # or if their parent section is not collapsed
+            else:
+                parent = field.get("parent_section")
+                if not parent or parent not in self._collapsed_sections:
+                    visible.append(field)
+        return visible
+
+    def _toggle_section(self, section_key: str) -> None:
+        """Toggle a section's collapsed state.
+
+        Args:
+            section_key: Key of the section to toggle
+        """
+        if section_key in self._collapsed_sections:
+            self._collapsed_sections.remove(section_key)
+        else:
+            self._collapsed_sections.add(section_key)
 
     def run_settings_menu(self, io_adapter, settings) -> SettingsResult:
         """Run the settings menu loop until user confirms or cancels.
@@ -74,20 +121,40 @@ class SettingsHandler:
         """
         selected_index = 0
 
+        # Initialize collapsed sections from field definitions (only once)
+        self._initialize_collapsed_sections(settings.MENU_FIELDS)
+
         # Snapshot original values of critical settings that need reset
         original_values = {key: settings.get(key) for key in self.CRITICAL_SETTINGS}
 
         # Event loop
         while True:
+            # Get visible fields (filtered by collapsed sections)
+            visible_fields = self._get_visible_fields(settings.MENU_FIELDS)
+
+            # Clamp selected index to visible range
+            if selected_index >= len(visible_fields):
+                selected_index = len(visible_fields) - 1
+            if selected_index < 0:
+                selected_index = 0
+
             # Get current settings values as dict for renderer
+            # include section collapse state
             settings_values = {
                 field["key"]: settings.get(field["key"])
                 for field in settings.MENU_FIELDS
+                if field["type"] != "section"
             }
+            # add collapse state for sections
+            for field in settings.MENU_FIELDS:
+                if field["type"] == "section":
+                    settings_values[field["key"]] = (
+                        field["key"] not in self._collapsed_sections
+                    )
 
             # Render settings menu using renderer's built-in method
             self._renderer.draw_settings_menu(
-                settings.MENU_FIELDS, selected_index, settings_values
+                visible_fields, selected_index, settings_values
             )
             io_adapter.update_display()
 
@@ -102,8 +169,8 @@ class SettingsHandler:
                 if event.type == pygame.KEYDOWN:
                     key = event.key
 
-                    # Exit menu (save changes)
-                    if key in (pygame.K_ESCAPE, pygame.K_RETURN):
+                    # Exit menu (save changes) - only on ESC
+                    if key == pygame.K_ESCAPE:
                         # Check if critical settings changed
                         needs_reset = any(
                             settings.get(k) != original_values[k]
@@ -111,26 +178,30 @@ class SettingsHandler:
                         )
                         return SettingsResult(needs_reset=needs_reset, canceled=False)
 
+                    # Enter key toggles section expand/collapse
+                    elif key == pygame.K_RETURN:
+                        current_field = visible_fields[selected_index]
+                        if current_field["type"] == "section":
+                            self._toggle_section(current_field["key"])
+
                     # Navigate down
                     elif key in (pygame.K_DOWN, pygame.K_s):
-                        selected_index = (selected_index + 1) % len(
-                            settings.MENU_FIELDS
-                        )
+                        selected_index = (selected_index + 1) % len(visible_fields)
 
                     # Navigate up
                     elif key in (pygame.K_UP, pygame.K_w):
-                        selected_index = (selected_index - 1) % len(
-                            settings.MENU_FIELDS
-                        )
+                        selected_index = (selected_index - 1) % len(visible_fields)
 
                     # Decrease value
                     elif key in (pygame.K_LEFT, pygame.K_a):
-                        settings.step_setting(settings.MENU_FIELDS[selected_index], -1)
+                        current_field = visible_fields[selected_index]
+                        settings.step_setting(current_field, -1)
 
                     # Increase value
                     elif key in (pygame.K_RIGHT, pygame.K_d):
-                        settings.step_setting(settings.MENU_FIELDS[selected_index], +1)
+                        current_field = visible_fields[selected_index]
+                        settings.step_setting(current_field, +1)
 
                     # Random colors (special key)
                     elif key == pygame.K_c:
-                        settings.randomize_colors()
+                        settings.randomize_snake_colors()

--- a/src/game/game_mode_settings.py
+++ b/src/game/game_mode_settings.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Game mode-specific settings configuration.
+
+This module defines the available game modes and their specific settings.
+Each game mode can have its own unique configuration options that only
+appear when that mode is selected.
+"""
+
+# Available game modes
+GAME_MODES = [
+    "Classic",
+    # future modes can be added here:
+    # "Box Mode",
+    # "Cheese Mode",
+    # "Tail Mode",
+    # "Shrinking Snake Mode",
+]
+
+
+# Mapping from game mode to mode-specific settings
+# Each mode can define additional settings fields that will appear
+# in the "Game Mode Settings" section when that mode is selected
+GAME_MODE_SETTINGS = {
+    "Classic": {
+        "description": "Traditional snake game with no special mechanics",
+        "settings": [
+            # no mode-specific settings for classic mode yet
+            # future settings can be added here
+        ],
+    },
+    # example of how to add mode-specific settings in the future:
+    # "Box Mode": {
+    #     "description": "Push boxes around the arena",
+    #     "settings": [
+    #         {
+    #             "key": "box_count",
+    #             "label": "  Number of Boxes",
+    #             "type": "int",
+    #             "min": 1,
+    #             "max": 5,
+    #             "step": 1,
+    #             "default": 1,
+    #         },
+    #         {
+    #             "key": "box_speed_boost",
+    #             "label": "  Speed Boost on Push",
+    #             "type": "bool",
+    #             "default": False,
+    #         },
+    #     ],
+    # },
+    # "Shrinking Snake Mode": {
+    #     "description": "Snake shrinks instead of growing",
+    #     "settings": [
+    #         {
+    #             "key": "initial_snake_length",
+    #             "label": "  Initial Snake Length",
+    #             "type": "int",
+    #             "min": 5,
+    #             "max": 20,
+    #             "step": 1,
+    #             "default": 10,
+    #         },
+    #         {
+    #             "key": "speed_increase_on_eat",
+    #             "label": "  Speed Increase on Eating",
+    #             "type": "bool",
+    #             "default": False,
+    #         },
+    #     ],
+    # },
+}
+
+
+def get_mode_settings(mode_name: str) -> list[dict]:
+    """Get the settings fields for a specific game mode.
+
+    Args:
+        mode_name: Name of the game mode
+
+    Returns:
+        List of setting field definitions for this mode
+    """
+    mode_config = GAME_MODE_SETTINGS.get(mode_name, {})
+    return mode_config.get("settings", [])
+
+
+def get_mode_description(mode_name: str) -> str:
+    """Get the description for a specific game mode.
+
+    Args:
+        mode_name: Name of the game mode
+
+    Returns:
+        Description string for this mode
+    """
+    mode_config = GAME_MODE_SETTINGS.get(mode_name, {})
+    return mode_config.get("description", "")
+
+
+def get_mode_defaults(mode_name: str) -> dict:
+    """Get default values for all mode-specific settings.
+
+    Args:
+        mode_name: Name of the game mode
+
+    Returns:
+        Dictionary mapping setting keys to their default values
+    """
+    settings = get_mode_settings(mode_name)
+    return {
+        field["key"]: field.get("default") for field in settings if "default" in field
+    }

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -128,6 +128,12 @@ class GameplayScene(BaseScene):
             audio_service=self._audio_service, scoring_system=scoring_system
         )
 
+        # Create overlay_render_system early so it can be passed to InputSystem
+        if self._renderer:
+            self._overlay_render_system = OverlayRenderSystem(
+                self._renderer, self._settings, self._config
+            )
+
         # game logic systems (indices 0-7, paused during pause)
         from ecs.systems.apple_spawn import AppleSpawnSystem
         from ecs.systems.autoplay import AutoplaySystem
@@ -139,7 +145,10 @@ class GameplayScene(BaseScene):
         # build game logic systems list
         game_logic_systems = [
             InputSystem(
-                self._pygame_adapter, self._settings, self._current_game_mode
+                self._pygame_adapter,
+                self._settings,
+                self._current_game_mode,
+                self._overlay_render_system,
             ),  # 0: read user input and update velocity/game state
             autoplay_system,  # 1: calculate next move in autoplay mode (with victory handling)
             MovementSystem(
@@ -223,9 +232,7 @@ class GameplayScene(BaseScene):
                 self._renderer, self._settings
             )
             self._ui_render_system = UIRenderSystem(self._renderer, self._settings)
-            self._overlay_render_system = OverlayRenderSystem(
-                self._renderer, self._settings, self._config
-            )
+            # overlay_render_system already created earlier (before InputSystem)
             self._systems.extend(
                 [
                     self._board_render_system,

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -59,11 +59,47 @@ class SettingsScene(BaseScene):
         self._settings = settings
         self._config = config
         self._selected_index = 0
-        # total menu items = settings fields + "Reset to Default" button
+        # track which sections are collapsed
+        self._collapsed_sections = set()
+        # initialize collapsed sections from field definitions (only once)
+        for field in self._settings.MENU_FIELDS:
+            if field["type"] == "section" and field.get("collapsed", False):
+                self._collapsed_sections.add(field["key"])
+        # total menu items = visible settings fields + "Reset to Default" button
         self._total_menu_items = len(self._settings.MENU_FIELDS) + 1
-        # Hover state for warning tooltips
+        # hover state for warning tooltips
         self._hovered_warning_key = None
         self._warning_icon_rects = {}  # key -> rect for hover detection
+
+    def _get_visible_fields(self) -> list[dict]:
+        """Get only the fields that should be visible based on section collapse state.
+
+        Returns:
+            List of visible fields
+        """
+        visible = []
+        for field in self._settings.MENU_FIELDS:
+            # section headers are always visible
+            if field["type"] == "section":
+                visible.append(field)
+            # regular fields are visible if they don't have a parent section,
+            # or if their parent section is not collapsed
+            else:
+                parent = field.get("parent_section")
+                if not parent or parent not in self._collapsed_sections:
+                    visible.append(field)
+        return visible
+
+    def _toggle_section(self, section_key: str) -> None:
+        """Toggle a section's collapsed state.
+
+        Args:
+            section_key: Key of the section to toggle
+        """
+        if section_key in self._collapsed_sections:
+            self._collapsed_sections.remove(section_key)
+        else:
+            self._collapsed_sections.add(section_key)
 
     def update(self, dt_ms: float) -> Optional[str]:
         """Update settings logic.
@@ -74,12 +110,22 @@ class SettingsScene(BaseScene):
         Returns:
             Next scene name or None
         """
+        # Get visible fields
+        visible_fields = self._get_visible_fields()
+
+        # Clamp selected index to visible range
+        if self._selected_index >= len(visible_fields):
+            self._selected_index = len(visible_fields) - 1
+        if self._selected_index < 0:
+            self._selected_index = 0
+
         # Update key holding state (this handles continuous changes)
         # Only update if not on "Reset to Default" button
-        if self._selected_index < len(self._settings.MENU_FIELDS):
-            if self._settings.update_key_hold():
+        if self._selected_index < len(visible_fields):
+            current_field = visible_fields[self._selected_index]
+            # only update if not a section
+            if current_field["type"] != "section" and self._settings.update_key_hold():
                 # A value was updated by key holding
-                current_field = self._settings.MENU_FIELDS[self._selected_index]
                 self._apply_audio_setting_if_changed(current_field["key"])
 
         # Handle input
@@ -95,32 +141,42 @@ class SettingsScene(BaseScene):
                     return "menu"  # back to menu
                 elif event.key == pygame.K_RETURN:
                     # Check if "Reset to Default" is selected
-                    if self._selected_index == len(self._settings.MENU_FIELDS):
+                    if self._selected_index == len(visible_fields):
                         self._settings.reset_to_defaults()
                         self._settings.save_settings()
                         # Stay in settings to show the reset took effect
-                    else:
-                        # Regular return to menu
-                        self._settings.stop_key_hold()
-                        return "menu"
+                    elif self._selected_index < len(visible_fields):
+                        # toggle section if selected field is a section
+                        current_field = visible_fields[self._selected_index]
+                        print(
+                            f"[DEBUG] Enter pressed on field: {current_field.get('label')} (type: {current_field.get('type')})"
+                        )
+                        if current_field["type"] == "section":
+                            print(f"[DEBUG] Toggling section: {current_field['key']}")
+                            self._toggle_section(current_field["key"])
+                            print(f"[DEBUG] Collapsed sections: {self._collapsed_sections}")
+                        else:
+                            # Regular field - return to menu
+                            self._settings.stop_key_hold()
+                            return "menu"
                 elif event.key in (pygame.K_DOWN, pygame.K_s):
                     # Stop key hold when changing selection
                     self._settings.stop_key_hold()
-                    self._selected_index = (
-                        self._selected_index + 1
-                    ) % self._total_menu_items
+                    # navigate through visible fields + reset button
+                    total_items = len(visible_fields) + 1
+                    self._selected_index = (self._selected_index + 1) % total_items
                 elif event.key in (pygame.K_UP, pygame.K_w):
                     # Stop key hold when changing selection
                     self._settings.stop_key_hold()
-                    self._selected_index = (
-                        self._selected_index - 1
-                    ) % self._total_menu_items
+                    # navigate through visible fields + reset button
+                    total_items = len(visible_fields) + 1
+                    self._selected_index = (self._selected_index - 1) % total_items
                 elif event.key in (pygame.K_LEFT, pygame.K_a):
                     # Only handle left/right on settings fields, not on "Reset to Default"
-                    if self._selected_index < len(self._settings.MENU_FIELDS):
-                        current_field = self._settings.MENU_FIELDS[self._selected_index]
-                        # Skip if setting is restricted (locked)
-                        if not self._settings.is_setting_restricted(
+                    if self._selected_index < len(visible_fields):
+                        current_field = visible_fields[self._selected_index]
+                        # Skip if field is a section or setting is restricted (locked)
+                        if current_field["type"] != "section" and not self._settings.is_setting_restricted(
                             current_field["key"]
                         ):
                             # Start holding left
@@ -129,10 +185,10 @@ class SettingsScene(BaseScene):
                             self._apply_audio_setting_if_changed(current_field["key"])
                 elif event.key in (pygame.K_RIGHT, pygame.K_d):
                     # Only handle left/right on settings fields, not on "Reset to Default"
-                    if self._selected_index < len(self._settings.MENU_FIELDS):
-                        current_field = self._settings.MENU_FIELDS[self._selected_index]
-                        # Skip if setting is restricted (locked)
-                        if not self._settings.is_setting_restricted(
+                    if self._selected_index < len(visible_fields):
+                        current_field = visible_fields[self._selected_index]
+                        # Skip if field is a section or setting is restricted (locked)
+                        if current_field["type"] != "section" and not self._settings.is_setting_restricted(
                             current_field["key"]
                         ):
                             # Start holding right
@@ -210,10 +266,17 @@ class SettingsScene(BaseScene):
         current_y = padding_y - scroll_offset
         current_category = None
 
+        # Get visible fields (respecting section collapse state)
+        visible_fields = self._get_visible_fields()
+
         # Draw settings grouped by category
-        for field_i, f in enumerate(self._settings.MENU_FIELDS):
-            # Draw category header if this is a new category
-            if f.get("category") != current_category:
+        for field_i, f in enumerate(visible_fields):
+            # skip category headers for section headers and their children
+            is_section_child = f.get("parent_section") is not None
+            is_section = f.get("type") == "section"
+
+            # Draw category header if this is a new category (but not for sections or section children)
+            if not is_section and not is_section_child and f.get("category") != current_category:
                 current_category = f.get("category", "Other")
 
                 # Add spacing before category (except first)
@@ -236,81 +299,101 @@ class SettingsScene(BaseScene):
 
             # Draw setting field only if visible
             if content_start_y - row_h <= current_y <= content_end_y:
-                val = self._settings.get(f["key"])
+                # handle section headers specially
+                if f["type"] == "section":
+                    # section headers get a collapse indicator
+                    is_expanded = f["key"] not in self._collapsed_sections
+                    indicator = "v" if is_expanded else ">"
+                    label_text = f"{indicator} {f['label']}"
 
-                # Calculate current grid size for display
-                current_grid_size = 20
-                if self._config:
-                    desired_cells = max(10, int(self._settings.get("cells_per_side")))
-                    current_grid_size = self._config.get_optimal_grid_size(
-                        desired_cells
+                    # make section headers slightly larger
+                    color = SCORE_COLOR if field_i == self._selected_index else MESSAGE_COLOR
+                    text = self._assets.render_custom(
+                        label_text,
+                        color,
+                        int(self._width / 28),
                     )
-
-                formatted_val = self._settings.format_setting_value(
-                    f,
-                    val,
-                    self._width,
-                    current_grid_size,
-                )
-
-                # Check if setting is restricted
-                is_restricted = self._settings.is_setting_restricted(f["key"])
-
-                # Highlight selected item (dim color if restricted)
-                if is_restricted:
-                    # Restricted settings shown in orange/amber
-                    color = (
-                        (255, 180, 60)
-                        if field_i == self._selected_index
-                        else (180, 130, 60)
-                    )
+                    rect = text.get_rect()
+                    rect.left = left_margin - category_indent
+                    rect.top = current_y
+                    self._renderer.blit(text, rect)
                 else:
-                    color = (
-                        SCORE_COLOR
-                        if field_i == self._selected_index
-                        else MESSAGE_COLOR
-                    )
-                text = self._assets.render_custom(
-                    f"{f['label']}: {formatted_val}",
-                    color,
-                    int(self._width / 32),
-                )
-                rect = text.get_rect()
-                rect.left = left_margin
-                rect.top = current_y
-                self._renderer.blit(text, rect)
+                    # regular fields
+                    val = self._settings.get(f["key"])
 
-                # Draw warning indicator if restricted
-                if is_restricted:
-                    # Draw [!] warning icon
-                    warning_icon = self._assets.render_custom(
-                        "[!]",
-                        (255, 200, 50),  # Amber/yellow warning color
+                    # Calculate current grid size for display
+                    current_grid_size = 20
+                    if self._config:
+                        desired_cells = max(10, int(self._settings.get("cells_per_side")))
+                        current_grid_size = self._config.get_optimal_grid_size(
+                            desired_cells
+                        )
+
+                    formatted_val = self._settings.format_setting_value(
+                        f,
+                        val,
+                        self._width,
+                        current_grid_size,
+                    )
+
+                    # Check if setting is restricted
+                    is_restricted = self._settings.is_setting_restricted(f["key"])
+
+                    # Highlight selected item (dim color if restricted)
+                    if is_restricted:
+                        # Restricted settings shown in orange/amber
+                        color = (
+                            (255, 180, 60)
+                            if field_i == self._selected_index
+                            else (180, 130, 60)
+                        )
+                    else:
+                        color = (
+                            SCORE_COLOR
+                            if field_i == self._selected_index
+                            else MESSAGE_COLOR
+                        )
+                    text = self._assets.render_custom(
+                        f"{f['label']}: {formatted_val}",
+                        color,
                         int(self._width / 32),
                     )
-                    icon_rect = warning_icon.get_rect()
-                    icon_rect.left = rect.right + 8
-                    icon_rect.centery = rect.centery
-                    self._renderer.blit(warning_icon, icon_rect)
-                    # Store rect for hover detection
-                    self._warning_icon_rects[f["key"]] = icon_rect
+                    rect = text.get_rect()
+                    rect.left = left_margin
+                    rect.top = current_y
+                    self._renderer.blit(text, rect)
 
-                    # Draw LOCKED label
-                    locked_text = self._assets.render_custom(
-                        "LOCKED",
-                        (180, 80, 80),  # Red-ish color
-                        int(self._width / 45),
-                    )
-                    locked_rect = locked_text.get_rect()
-                    locked_rect.left = icon_rect.right + 8
-                    locked_rect.centery = rect.centery
-                    self._renderer.blit(locked_text, locked_rect)
+                    # Draw warning indicator if restricted
+                    if is_restricted:
+                        # Draw [!] warning icon
+                        warning_icon = self._assets.render_custom(
+                            "[!]",
+                            (255, 200, 50),  # Amber/yellow warning color
+                            int(self._width / 32),
+                        )
+                        icon_rect = warning_icon.get_rect()
+                        icon_rect.left = rect.right + 8
+                        icon_rect.centery = rect.centery
+                        self._renderer.blit(warning_icon, icon_rect)
+                        # Store rect for hover detection
+                        self._warning_icon_rects[f["key"]] = icon_rect
+
+                        # Draw LOCKED label
+                        locked_text = self._assets.render_custom(
+                            "LOCKED",
+                            (180, 80, 80),  # Red-ish color
+                            int(self._width / 45),
+                        )
+                        locked_rect = locked_text.get_rect()
+                        locked_rect.left = icon_rect.right + 8
+                        locked_rect.centery = rect.centery
+                        self._renderer.blit(locked_text, locked_rect)
 
             current_y += row_h
 
         # Draw "Reset to Default" button
         current_y += int(self._height * 0.04)
-        reset_index = len(self._settings.MENU_FIELDS)
+        reset_index = len(visible_fields)
 
         # Only draw if visible
         if content_start_y - row_h <= current_y <= content_end_y:
@@ -325,7 +408,7 @@ class SettingsScene(BaseScene):
             self._renderer.blit(reset_text, reset_rect)
 
         # Hint footer
-        hint_text = "[A/D] change   [W/S] select   [Enter/Esc] back   [C] random colors"
+        hint_text = "[A/D] change   [W/S] select   [Enter] toggle/exit   [Esc] back   [C] random"
         hint = self._assets.render_custom(hint_text, GRID_COLOR, int(self._width / 50))
         self._renderer.blit(
             hint, hint.get_rect(center=(self._width / 2, self._height * 0.95))

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -154,7 +154,9 @@ class SettingsScene(BaseScene):
                         if current_field["type"] == "section":
                             print(f"[DEBUG] Toggling section: {current_field['key']}")
                             self._toggle_section(current_field["key"])
-                            print(f"[DEBUG] Collapsed sections: {self._collapsed_sections}")
+                            print(
+                                f"[DEBUG] Collapsed sections: {self._collapsed_sections}"
+                            )
                         else:
                             # Regular field - return to menu
                             self._settings.stop_key_hold()
@@ -176,7 +178,9 @@ class SettingsScene(BaseScene):
                     if self._selected_index < len(visible_fields):
                         current_field = visible_fields[self._selected_index]
                         # Skip if field is a section or setting is restricted (locked)
-                        if current_field["type"] != "section" and not self._settings.is_setting_restricted(
+                        if current_field[
+                            "type"
+                        ] != "section" and not self._settings.is_setting_restricted(
                             current_field["key"]
                         ):
                             # Start holding left
@@ -188,7 +192,9 @@ class SettingsScene(BaseScene):
                     if self._selected_index < len(visible_fields):
                         current_field = visible_fields[self._selected_index]
                         # Skip if field is a section or setting is restricted (locked)
-                        if current_field["type"] != "section" and not self._settings.is_setting_restricted(
+                        if current_field[
+                            "type"
+                        ] != "section" and not self._settings.is_setting_restricted(
                             current_field["key"]
                         ):
                             # Start holding right
@@ -276,7 +282,11 @@ class SettingsScene(BaseScene):
             is_section = f.get("type") == "section"
 
             # Draw category header if this is a new category (but not for sections or section children)
-            if not is_section and not is_section_child and f.get("category") != current_category:
+            if (
+                not is_section
+                and not is_section_child
+                and f.get("category") != current_category
+            ):
                 current_category = f.get("category", "Other")
 
                 # Add spacing before category (except first)
@@ -307,7 +317,11 @@ class SettingsScene(BaseScene):
                     label_text = f"{indicator} {f['label']}"
 
                     # make section headers slightly larger
-                    color = SCORE_COLOR if field_i == self._selected_index else MESSAGE_COLOR
+                    color = (
+                        SCORE_COLOR
+                        if field_i == self._selected_index
+                        else MESSAGE_COLOR
+                    )
                     text = self._assets.render_custom(
                         label_text,
                         color,
@@ -324,7 +338,9 @@ class SettingsScene(BaseScene):
                     # Calculate current grid size for display
                     current_grid_size = 20
                     if self._config:
-                        desired_cells = max(10, int(self._settings.get("cells_per_side")))
+                        desired_cells = max(
+                            10, int(self._settings.get("cells_per_side"))
+                        )
                         current_grid_size = self._config.get_optimal_grid_size(
                             desired_cells
                         )

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -46,6 +46,7 @@ class GameSettings:
         "speed_increase_rate": "10%",  # Speed increase per apple: 5% or 10%
         "enable_hunger": False,
         "segment_borders": False,  # Dark borders around snake segments
+        "game_mode": "Classic",  # current game mode
     }
 
     # Settings that are restricted/forced for Autoplay mode
@@ -188,6 +189,18 @@ class GameSettings:
             "options": [palette["name"] for palette in BOARD_COLOR_PALETTES],
             "requires_reset": False,
             "category": "Display",
+        },
+        {
+            "key": "game_mode_section",
+            "label": "Game Mode Settings",
+            "type": "section",
+            "collapsed": True,  # starts collapsed
+        },
+        {
+            "key": "game_mode",
+            "label": "  Current Mode",
+            "type": "readonly",
+            "parent_section": "game_mode_section",
         },
     ]
 
@@ -388,7 +401,13 @@ class GameSettings:
         Returns:
             Formatted string representation of the value
         """
-        if field["key"] == "cells_per_side":
+        if field["type"] == "section":
+            # section headers don't have values
+            return ""
+        elif field["type"] == "readonly":
+            # readonly fields just display the value
+            return str(value)
+        elif field["key"] == "cells_per_side":
             # Show the saved value directly (the internal value)
             grid_str = f"{int(value)} × {int(value)}"
             # Add note for AutoPlay mode about even grid requirement
@@ -472,6 +491,10 @@ class GameSettings:
         """
         key = field["key"]
         kind = field["type"]
+
+        # readonly and section fields cannot be changed
+        if kind in ("readonly", "section"):
+            return
 
         if kind == "bool":
             if key not in self.settings:
@@ -594,7 +617,7 @@ class GameSettings:
         ]
 
     def scoreboard_settings(self) -> dict[str, Any]:
-        relevant_settings = {v["key"] for v in self.MENU_FIELDS if v["requires_reset"]}
+        relevant_settings = {v["key"] for v in self.MENU_FIELDS if v.get("requires_reset", False)}
         filtered_settings = {
             k: v for k, v in self.settings.items() if k in relevant_settings
         }

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -617,7 +617,9 @@ class GameSettings:
         ]
 
     def scoreboard_settings(self) -> dict[str, Any]:
-        relevant_settings = {v["key"] for v in self.MENU_FIELDS if v.get("requires_reset", False)}
+        relevant_settings = {
+            v["key"] for v in self.MENU_FIELDS if v.get("requires_reset", False)
+        }
         filtered_settings = {
             k: v for k, v in self.settings.items() if k in relevant_settings
         }


### PR DESCRIPTION
**What**

Add Collapsible Game Mode section to settings, both in the main menu and in the in-game settings (pause settings)

The section can be toggled with enter and shows current game mode info (current only the game mode name, but can be extended in the future)

<img width="703" height="134" alt="v Game Mode Settings" src="https://github.com/user-attachments/assets/082925eb-8149-4a15-9cd5-a36aaa179dff" />

Closes #445 