### PR TITLE
[BUG] Fix contrast of hint text in settings menu

### DIFF
--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -386,7 +386,7 @@ class OverlayRenderSystem(BaseSystem):
             hint_font = pygame.font.Font(None, hint_font_size)
 
         hint_surf = hint_font.render(
-            hint_text, True, Color.from_hex(constants.GRID_COLOR).to_tuple()
+            hint_text, True, Color.from_hex(constants.MESSAGE_COLOR).to_tuple()
         )
         hint_rect = hint_surf.get_rect(
             center=(surface_width / 2, surface_height * 0.95)

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -27,7 +27,7 @@ from typing import Optional
 from game.scenes.base_scene import BaseScene
 from game.services.assets import GameAssets
 from game.settings import GameSettings
-from game.constants import ARENA_PRIMARY_COLOR, MESSAGE_COLOR, SCORE_COLOR, GRID_COLOR
+from game.constants import ARENA_PRIMARY_COLOR, MESSAGE_COLOR, SCORE_COLOR
 
 
 class SettingsScene(BaseScene):
@@ -472,7 +472,9 @@ class SettingsScene(BaseScene):
 
         # Hint footer
         hint_text = "[A/D] change   [W/S] select   [Enter] toggle/exit   [Esc] back   [C] random"
-        hint = self._assets.render_custom(hint_text, GRID_COLOR, int(self._width / 50))
+        hint = self._assets.render_custom(
+            hint_text, MESSAGE_COLOR, int(self._width / 50)
+        )
         self._renderer.blit(
             hint, hint.get_rect(center=(self._width / 2, self._height * 0.95))
         )


### PR DESCRIPTION
I just changed the color of the hint text from GRID_COLOR to MESSAGE_COLOR, making the text visible on any background color. I took the opportunity to change the color of the hint text on the start menu to make it standard. Closes #465.

Pink background:
<img width="953" height="592" alt="solved-pink-bg" src="https://github.com/user-attachments/assets/78b19a27-cdfa-4d61-aafa-5e682ca89283" />

Orange background:
<img width="952" height="592" alt="solved-orange-bg" src="https://github.com/user-attachments/assets/7aa0cd2f-ce13-40a6-8417-7f3a1115e8bc" />

Green background:
<img width="955" height="592" alt="solved-green-bg" src="https://github.com/user-attachments/assets/d52ee376-2212-4d8b-8878-40adb9f1512d" />

Blue background:
<img width="955" height="593" alt="solved-blue-bg" src="https://github.com/user-attachments/assets/126bc7b8-9751-4e28-a19f-4c44cfe9c3a5" />

Purple background:
<img width="952" height="593" alt="solved-purple-bg" src="https://github.com/user-attachments/assets/4b7a7de7-24b8-4026-8ba7-196251096894" />




