### PR TITLE
 [FEAT] Add Player vs Player (Local) Game Mode 

### DIFF
--- a/src/ecs/components/lives.py
+++ b/src/ecs/components/lives.py
@@ -31,4 +31,3 @@ class Lives:
 
     remaining: int = 3  # number of lives left
     max_lives: int = 3  # maximum lives
-

--- a/src/ecs/components/lives.py
+++ b/src/ecs/components/lives.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Lives component for tracking snake lives in PvP mode."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Lives:
+    """Tracks remaining lives for a snake.
+
+    Used by: Snake (in Player vs Player mode)
+    """
+
+    remaining: int = 3  # number of lives left
+    max_lives: int = 3  # maximum lives
+

--- a/src/ecs/components/player_id.py
+++ b/src/ecs/components/player_id.py
@@ -31,4 +31,3 @@ class PlayerID:
 
     player_number: int  # 1 for Player 1 (WASD), 2 for Player 2 (Arrows)
     score: int = 0  # individual player score
-

--- a/src/ecs/components/player_id.py
+++ b/src/ecs/components/player_id.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Player ID component for distinguishing players in PvP mode."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PlayerID:
+    """Identifies which player controls this snake.
+
+    Used by: Snake (in Player vs Player mode)
+    """
+
+    player_number: int  # 1 for Player 1 (WASD), 2 for Player 2 (Arrows)
+    score: int = 0  # individual player score
+

--- a/src/ecs/components/respawn_timer.py
+++ b/src/ecs/components/respawn_timer.py
@@ -30,5 +30,6 @@ class RespawnTimer:
     """
 
     time_remaining_ms: float = 0.0  # milliseconds until respawn
-    is_respawning: bool = False  # whether snake is currently dead and waiting to respawn
-
+    is_respawning: bool = (
+        False  # whether snake is currently dead and waiting to respawn
+    )

--- a/src/ecs/components/respawn_timer.py
+++ b/src/ecs/components/respawn_timer.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Respawn timer component for handling snake respawns."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class RespawnTimer:
+    """Tracks respawn cooldown for dead snakes.
+
+    Used by: Snake (in Player vs Player mode)
+    """
+
+    time_remaining_ms: float = 0.0  # milliseconds until respawn
+    is_respawning: bool = False  # whether snake is currently dead and waiting to respawn
+

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -79,12 +79,12 @@ def create_snake(
     # starting position in GRID COORDINATES (not pixels)
     # use provided position or default to board center
     if initial_x is None:
-    start_x = world.board.width // 2
+        start_x = world.board.width // 2
     else:
         start_x = initial_x
     
     if initial_y is None:
-    start_y = world.board.height // 2
+        start_y = world.board.height // 2
     else:
         start_y = initial_y
 

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -79,12 +79,12 @@ def create_snake(
     # starting position in GRID COORDINATES (not pixels)
     # use provided position or default to board center
     if initial_x is None:
-        start_x = world.board.width // 2
+    start_x = world.board.width // 2
     else:
         start_x = initial_x
     
     if initial_y is None:
-        start_y = world.board.height // 2
+    start_y = world.board.height // 2
     else:
         start_y = initial_y
 

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -43,6 +43,8 @@ def create_snake(
     cheese_mode: bool = False,
     shrinking_mode: bool = False,
     autoplay_mode: bool = False,
+    initial_x: Optional[int] = None,
+    initial_y: Optional[int] = None,
 ) -> int:
     """Create a snake entity with all required components.
 
@@ -56,6 +58,8 @@ def create_snake(
         cheese_mode: Whether Cheese Mode is enabled (affects initial size)
         shrinking_mode: Whether Shrinking Mode is enabled (starts large)
         autoplay_mode: Whether Autoplay Mode is enabled (starts with zero velocity)
+        initial_x: Initial X position in grid coordinates (default: center)
+        initial_y: Initial Y position in grid coordinates (default: center)
 
     Returns:
         int: Entity ID of created snake
@@ -73,9 +77,16 @@ def create_snake(
         tail_color = (0, 255, 0)  # light green
 
     # starting position in GRID COORDINATES (not pixels)
-    # board center
+    # use provided position or default to board center
+    if initial_x is None:
     start_x = world.board.width // 2
+    else:
+        start_x = initial_x
+    
+    if initial_y is None:
     start_y = world.board.height // 2
+    else:
+        start_y = initial_y
 
     # Initialize body based on game mode
     if shrinking_mode:

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -82,7 +82,7 @@ def create_snake(
         start_x = world.board.width // 2
     else:
         start_x = initial_x
-    
+
     if initial_y is None:
         start_y = world.board.height // 2
     else:

--- a/src/ecs/systems/board_render.py
+++ b/src/ecs/systems/board_render.py
@@ -211,14 +211,26 @@ class BoardRenderSystem(BaseSystem):
             world: Game world to render
         """
         # Check if game is over - render only background if dead
+        # BUT: Don't stop rendering in PvP mode where snakes can respawn
         from ecs.entities.entity import EntityType
+        from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
 
-        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        # Check if we're in PvP mode
+        game_state_entities = world.registry.query_by_component("game_state")
+        is_pvp_mode = False
+        if game_state_entities:
+            entity = next(iter(game_state_entities.values()))
+            if hasattr(entity, "game_state"):
+                is_pvp_mode = entity.game_state.game_mode == PLAYER_VS_PLAYER_MODE_NAME
+
+        # Only check for game over in non-PvP modes
         game_over = False
-        for _, snake in snakes.items():
-            if hasattr(snake, "body") and not snake.body.alive:
-                game_over = True
-                break
+        if not is_pvp_mode:
+            snakes = world.registry.query_by_type(EntityType.SNAKE)
+            for _, snake in snakes.items():
+                if hasattr(snake, "body") and not snake.body.alive:
+                    game_over = True
+                    break
 
         # If game is over, render only arena background
         if game_over:

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -110,20 +110,20 @@ class CollisionSystem(BaseSystem):
             self._check_all_snakes_collisions(world)
         else:
             # Single player mode - check collisions for the single snake
-        # Check wall collision first (highest priority)
-        if self._check_wall_collision(world):
-            self._handle_death(world, "Wall collision")
-            return
+            # Check wall collision first (highest priority)
+            if self._check_wall_collision(world):
+                self._handle_death(world, "Wall collision")
+                return
 
-        # Check self-bite collision
-        if self._check_self_bite(world):
-            self._handle_death(world, "Self-bite collision")
-            return
+            # Check self-bite collision
+            if self._check_self_bite(world):
+                self._handle_death(world, "Self-bite collision")
+                return
 
-        # Check obstacle collision
-        if self._check_obstacle_collision(world):
-            self._handle_death(world, "Obstacle collision")
-            return
+            # Check obstacle collision
+            if self._check_obstacle_collision(world):
+                self._handle_death(world, "Obstacle collision")
+                return
 
             # Check box collision and push logic (Box Mode)
             self._check_box_collision(world)
@@ -131,8 +131,8 @@ class CollisionSystem(BaseSystem):
             # Check if any box is on a hole (Box Mode)
             self._check_all_box_hole_collisions(world)
 
-        # Check apple collision (doesn't kill)
-        self._check_apple_collision(world)
+            # Check apple collision (doesn't kill)
+            self._check_apple_collision(world)
 
     def _get_snake_entity(self, world: World):
         """Get the snake entity from the world.
@@ -964,7 +964,7 @@ class CollisionSystem(BaseSystem):
                                     except Exception:
                                         pass
                                 self._handle_death(world, "Win: shrunk to head")
-                        else:
+                    else:
                         if cheese_mode:
                             # Cheese mode: +2 growth via pending_growth
                             snake.body.pending_growth += 2

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -110,20 +110,20 @@ class CollisionSystem(BaseSystem):
             self._check_all_snakes_collisions(world)
         else:
             # Single player mode - check collisions for the single snake
-            # Check wall collision first (highest priority)
-            if self._check_wall_collision(world):
-                self._handle_death(world, "Wall collision")
-                return
+        # Check wall collision first (highest priority)
+        if self._check_wall_collision(world):
+            self._handle_death(world, "Wall collision")
+            return
 
-            # Check self-bite collision
-            if self._check_self_bite(world):
-                self._handle_death(world, "Self-bite collision")
-                return
+        # Check self-bite collision
+        if self._check_self_bite(world):
+            self._handle_death(world, "Self-bite collision")
+            return
 
-            # Check obstacle collision
-            if self._check_obstacle_collision(world):
-                self._handle_death(world, "Obstacle collision")
-                return
+        # Check obstacle collision
+        if self._check_obstacle_collision(world):
+            self._handle_death(world, "Obstacle collision")
+            return
 
             # Check box collision and push logic (Box Mode)
             self._check_box_collision(world)
@@ -131,8 +131,8 @@ class CollisionSystem(BaseSystem):
             # Check if any box is on a hole (Box Mode)
             self._check_all_box_hole_collisions(world)
 
-            # Check apple collision (doesn't kill)
-            self._check_apple_collision(world)
+        # Check apple collision (doesn't kill)
+        self._check_apple_collision(world)
 
     def _get_snake_entity(self, world: World):
         """Get the snake entity from the world.
@@ -965,12 +965,12 @@ class CollisionSystem(BaseSystem):
                                         pass
                                 self._handle_death(world, "Win: shrunk to head")
                         else:
-                            if cheese_mode:
-                                # Cheese mode: +2 growth via pending_growth
-                                snake.body.pending_growth += 2
-                            else:
-                                # Classic/other modes: +1 immediate growth
-                                snake.body.size += 1
+                        if cheese_mode:
+                            # Cheese mode: +2 growth via pending_growth
+                            snake.body.pending_growth += 2
+                        else:
+                            # Classic/other modes: +1 immediate growth
+                            snake.body.size += 1
 
                         if self._should_swap_head_and_tail(world):
                             self._swap_head_and_tail(snake)
@@ -1123,22 +1123,28 @@ class CollisionSystem(BaseSystem):
             snake.body.alive = False
             print(f"☠️ {player_name} has no lives left!")
             
-            # check if all snakes are dead
+            # check if all snakes are dead or only one remains
             from ecs.entities.entity import EntityType
             snakes = world.registry.query_by_type(EntityType.SNAKE)
+            alive_count = 0
             winner = None
-            for _, s in snakes.items():
-                if hasattr(s, "lives") and s.lives.remaining > 0:
-                    if hasattr(s, "player_id"):
-                        winner = s.player_id.player_number
-                    break
+            all_dead = True
             
-            if winner:
-                # game over - we have a winner
-                self._handle_death(world, f"Player {winner} wins!")
-            else:
-                # all snakes dead
+            for _, s in snakes.items():
+                if hasattr(s, "lives"):
+                    if s.lives.remaining > 0:
+                        alive_count += 1
+                        all_dead = False
+                        if hasattr(s, "player_id"):
+                            winner = s.player_id.player_number
+            
+            # Only trigger game over if all snakes are dead
+            if all_dead:
                 self._handle_death(world, "Draw! All players eliminated")
+            elif alive_count == 1 and winner:
+                # One winner remains - game over
+                self._handle_death(world, f"Player {winner} wins!")
+            # If alive_count > 1, game continues with remaining players
         else:
             # trigger respawn
             if self._respawn_system:

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -964,16 +964,17 @@ class CollisionSystem(BaseSystem):
                                     except Exception:
                                         pass
                                 self._handle_death(world, "Win: shrunk to head")
-                    else:
-                        if cheese_mode:
-                            # Cheese mode: +2 growth via pending_growth
-                            snake.body.pending_growth += 2
                         else:
-                            # Classic/other modes: +1 immediate growth
-                            snake.body.size += 1
+                            # Normal mode: grow the snake
+                            if cheese_mode:
+                                # Cheese mode: +2 growth via pending_growth
+                                snake.body.pending_growth += 2
+                            else:
+                                # Classic/other modes: +1 immediate growth
+                                snake.body.size += 1
 
-                        if self._should_swap_head_and_tail(world):
-                            self._swap_head_and_tail(snake)
+                            if self._should_swap_head_and_tail(world):
+                                self._swap_head_and_tail(snake)
 
                     # increment score using scoring system
                     if self._scoring_system:

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -101,32 +101,38 @@ class CollisionSystem(BaseSystem):
         Args:
             world: ECS world to query entities
         """
-        # Check wall collision first (highest priority)
-        if self._check_wall_collision(world):
-            self._handle_death(world, "Wall collision")
-            return
+        # Check if we're in PvP mode
+        game_state = self._get_game_state(world)
+        is_pvp_mode = game_state and game_state.game_mode == PLAYER_VS_PLAYER_MODE_NAME
 
-        # Check self-bite collision
-        if self._check_self_bite(world):
-            self._handle_death(world, "Self-bite collision")
-            return
+        if is_pvp_mode:
+            # In PvP mode, check collisions for each snake individually
+            self._check_all_snakes_collisions(world)
+        else:
+            # Single player mode - check collisions for the single snake
+            # Check wall collision first (highest priority)
+            if self._check_wall_collision(world):
+                self._handle_death(world, "Wall collision")
+                return
 
-        # Check player-vs-player collision (PvP mode)
-        self._check_player_vs_player_collision(world)
+            # Check self-bite collision
+            if self._check_self_bite(world):
+                self._handle_death(world, "Self-bite collision")
+                return
 
-        # Check obstacle collision
-        if self._check_obstacle_collision(world):
-            self._handle_death(world, "Obstacle collision")
-            return
+            # Check obstacle collision
+            if self._check_obstacle_collision(world):
+                self._handle_death(world, "Obstacle collision")
+                return
 
-        # Check box collision and push logic (Box Mode)
-        self._check_box_collision(world)
+            # Check box collision and push logic (Box Mode)
+            self._check_box_collision(world)
 
-        # Check if any box is on a hole (Box Mode)
-        self._check_all_box_hole_collisions(world)
+            # Check if any box is on a hole (Box Mode)
+            self._check_all_box_hole_collisions(world)
 
-        # Check apple collision (doesn't kill)
-        self._check_apple_collision(world)
+            # Check apple collision (doesn't kill)
+            self._check_apple_collision(world)
 
     def _get_snake_entity(self, world: World):
         """Get the snake entity from the world.
@@ -338,6 +344,184 @@ class CollisionSystem(BaseSystem):
                     return True
 
         return False
+
+    def _check_all_snakes_collisions(self, world: World) -> None:
+        """Check collisions for all snakes in PvP mode.
+
+        Args:
+            world: ECS world
+        """
+        from ecs.entities.entity import EntityType
+
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+
+        for snake_id, snake in snakes.items():
+            # skip if snake is not alive or respawning
+            if hasattr(snake, "body") and not snake.body.alive:
+                continue
+            if hasattr(snake, "respawn_timer") and snake.respawn_timer.is_respawning:
+                continue
+
+            # check wall collision for this snake
+            if self._check_wall_collision_for_snake(world, snake):
+                self._handle_snake_death(world, snake, "Wall collision")
+                continue
+
+            # check self-bite for this snake
+            if self._check_self_bite_for_snake(world, snake):
+                self._handle_snake_death(world, snake, "Self-bite collision")
+                continue
+
+            # check obstacle collision for this snake
+            if self._check_obstacle_collision_for_snake(world, snake):
+                self._handle_snake_death(world, snake, "Obstacle collision")
+                continue
+
+        # check player-vs-player collisions
+        self._check_player_vs_player_collision(world)
+
+        # check apple collisions for all snakes
+        self._check_apple_collision_all_snakes(world)
+
+    def _check_wall_collision_for_snake(self, world: World, snake) -> bool:
+        """Check wall collision for a specific snake.
+
+        Args:
+            world: ECS world
+            snake: Snake entity to check
+
+        Returns:
+            bool: True if collision detected
+        """
+        if not hasattr(snake, "position"):
+            return False
+
+        # get electric walls setting
+        electric_walls = (
+            self._settings.get("electric_walls") if self._settings else True
+        )
+
+        if not electric_walls:
+            return False
+
+        current_x = snake.position.x
+        current_y = snake.position.y
+        grid_width = world.board.width
+        grid_height = world.board.height
+
+        if (
+            current_x < 0
+            or current_x >= grid_width
+            or current_y < 0
+            or current_y >= grid_height
+        ):
+            return True
+
+        return False
+
+    def _check_self_bite_for_snake(self, world: World, snake) -> bool:
+        """Check self-bite collision for a specific snake.
+
+        Args:
+            world: ECS world
+            snake: Snake entity to check
+
+        Returns:
+            bool: True if collision detected
+        """
+        if not hasattr(snake, "position") or not hasattr(snake, "body"):
+            return False
+
+        head_x = snake.position.x
+        head_y = snake.position.y
+
+        # wrap if electric walls are disabled
+        electric_walls = (
+            self._settings.get("electric_walls") if self._settings else True
+        )
+        if not electric_walls:
+            head_x = head_x % world.board.width
+            head_y = head_y % world.board.height
+
+        # check collision with tail segments
+        for segment in snake.body.segments:
+            if head_x == segment.x and head_y == segment.y:
+                return True
+
+        return False
+
+    def _check_obstacle_collision_for_snake(self, world: World, snake) -> bool:
+        """Check obstacle collision for a specific snake.
+
+        Args:
+            world: ECS world
+            snake: Snake entity to check
+
+        Returns:
+            bool: True if collision detected
+        """
+        if not hasattr(snake, "position"):
+            return False
+
+        current_x = snake.position.x
+        current_y = snake.position.y
+
+        from ecs.entities.entity import EntityType
+
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+
+        for _, obstacle in obstacles.items():
+            if hasattr(obstacle, "position"):
+                if (
+                    current_x == obstacle.position.x
+                    and current_y == obstacle.position.y
+                ):
+                    return True
+
+        return False
+
+    def _check_apple_collision_all_snakes(self, world: World) -> None:
+        """Check apple collisions for all snakes in PvP mode.
+
+        Args:
+            world: ECS world
+        """
+        from ecs.entities.entity import EntityType
+
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        apples = world.registry.query_by_type(EntityType.APPLE)
+
+        for snake_id, snake in snakes.items():
+            # skip if snake is not alive or respawning
+            if hasattr(snake, "body") and not snake.body.alive:
+                continue
+            if hasattr(snake, "respawn_timer") and snake.respawn_timer.is_respawning:
+                continue
+            if not hasattr(snake, "position"):
+                continue
+
+            head_x = snake.position.x
+            head_y = snake.position.y
+
+            # check collision with apples
+            for apple_id, apple in list(apples.items()):
+                if hasattr(apple, "position"):
+                    if head_x == apple.position.x and head_y == apple.position.y:
+                        # play eating sound
+                        if self._audio_service:
+                            self._audio_service.play_sound("assets/sound/eat.flac")
+
+                        # grow snake
+                        if hasattr(snake, "body"):
+                            snake.body.size += 1
+
+                        # update player score
+                        if hasattr(snake, "player_id"):
+                            snake.player_id.score += 1
+
+                        # remove apple
+                        world.registry.remove(apple_id)
+                        break
 
     def _check_player_vs_player_collision(self, world: World) -> None:
         """Check collision between players in PvP mode.

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -1093,6 +1093,43 @@ class CollisionSystem(BaseSystem):
         else:
             print(f"☠️ DEATH CAUSE: {reason} (Service missing)")
 
+    def _determine_winner_by_score(self, world: World) -> int | None:
+        """Determine the winner based on final score (points - deaths).
+        
+        Args:
+            world: ECS world
+            
+        Returns:
+            Player number of the winner, or None if it's a draw
+        """
+        from ecs.entities.entity import EntityType
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        
+        player_scores = []
+        for _, snake in snakes.items():
+            if hasattr(snake, "player_id") and hasattr(snake, "lives"):
+                player_num = snake.player_id.player_number
+                points = snake.player_id.score
+                deaths = 3 - snake.lives.remaining
+                final_score = points - deaths
+                player_scores.append((player_num, final_score))
+        
+        if not player_scores:
+            return None
+        
+        # Sort by final score (descending)
+        player_scores.sort(key=lambda x: x[1], reverse=True)
+        
+        # Check if there's a clear winner (no tie)
+        if len(player_scores) == 1:
+            return player_scores[0][0]
+        
+        if player_scores[0][1] > player_scores[1][1]:
+            return player_scores[0][0]
+        
+        # It's a tie
+        return None
+    
     def _handle_snake_death(self, world: World, snake, reason: str) -> None:
         """Handle death of a specific snake in PvP mode.
 
@@ -1127,7 +1164,7 @@ class CollisionSystem(BaseSystem):
             from ecs.entities.entity import EntityType
             snakes = world.registry.query_by_type(EntityType.SNAKE)
             alive_count = 0
-            winner = None
+            alive_snakes = []
             all_dead = True
             
             for _, s in snakes.items():
@@ -1135,15 +1172,21 @@ class CollisionSystem(BaseSystem):
                     if s.lives.remaining > 0:
                         alive_count += 1
                         all_dead = False
-                        if hasattr(s, "player_id"):
-                            winner = s.player_id.player_number
+                        alive_snakes.append(s)
             
-            # Only trigger game over if all snakes are dead
+            # Determine game over condition
             if all_dead:
-                self._handle_death(world, "Draw! All players eliminated")
-            elif alive_count == 1 and winner:
-                # One winner remains - game over
-                self._handle_death(world, f"Player {winner} wins!")
+                # All snakes dead - determine winner by score
+                winner = self._determine_winner_by_score(world)
+                if winner:
+                    self._handle_death(world, f"Player {winner} WINS!!")
+                else:
+                    self._handle_death(world, "Draw! All players eliminated")
+            elif alive_count == 1:
+                # One survivor - determine winner by score
+                winner = self._determine_winner_by_score(world)
+                if winner:
+                    self._handle_death(world, f"Player {winner} WINS!!")
             # If alive_count > 1, game continues with remaining players
         else:
             # trigger respawn

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -36,7 +36,7 @@ from ecs.world import World
 from ecs.systems.scoring import ScoringSystem
 from game.settings import GameSettings
 from game.services.audio_service import AudioService
-from game.game_modes_registry import GAME_MODE_TELEPORT
+from game.game_modes_registry import GAME_MODE_TELEPORT, PLAYER_VS_PLAYER_MODE_NAME
 from game.services.game_over_service import GameOverService
 
 
@@ -71,6 +71,7 @@ class CollisionSystem(BaseSystem):
         audio_service: Optional[AudioService] = None,
         scoring_system: Optional[ScoringSystem] = None,
         game_over_service: Optional[GameOverService] = None,
+        respawn_system: Optional["RespawnSystem"] = None,
     ):
         """Initialize the CollisionSystem.
 
@@ -78,20 +79,24 @@ class CollisionSystem(BaseSystem):
             settings: Game settings for electric_walls, max_speed (GameSettings)
             audio_service: Audio service for playing sounds (AudioService)
             scoring_system: Scoring system for tracking score (ScoringSystem)
+            game_over_service: Game over service for handling game over
+            respawn_system: Respawn system for handling snake respawns in PvP
         """
         self._settings = settings
         self._audio_service = audio_service
         self._scoring_system = scoring_system
         self._game_over_service = game_over_service
+        self._respawn_system = respawn_system
 
     def update(self, world: World) -> None:
         """Check for all collision types in priority order.
 
-        Priority (same as old code):
+        Priority:
         1. Wall collision (electric mode only)
         2. Self-bite collision
-        3. Obstacle collision
-        4. Apple collision
+        3. Player-vs-player collision (PvP mode)
+        4. Obstacle collision
+        5. Apple collision
 
         Args:
             world: ECS world to query entities
@@ -105,6 +110,9 @@ class CollisionSystem(BaseSystem):
         if self._check_self_bite(world):
             self._handle_death(world, "Self-bite collision")
             return
+
+        # Check player-vs-player collision (PvP mode)
+        self._check_player_vs_player_collision(world)
 
         # Check obstacle collision
         if self._check_obstacle_collision(world):
@@ -330,6 +338,68 @@ class CollisionSystem(BaseSystem):
                     return True
 
         return False
+
+    def _check_player_vs_player_collision(self, world: World) -> None:
+        """Check collision between players in PvP mode.
+
+        In PvP mode, if a snake's head collides with another snake's
+        body or head, the colliding snake loses a life and respawns.
+
+        Args:
+            world: ECS world
+        """
+        # only run in Player vs Player mode
+        game_state = self._get_game_state(world)
+        if not game_state or game_state.game_mode != PLAYER_VS_PLAYER_MODE_NAME:
+            return
+
+        from ecs.entities.entity import EntityType
+
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        snake_list = list(snakes.items())
+
+        # check each snake against all other snakes
+        for snake_id, snake in snake_list:
+            # skip if snake is not alive or respawning
+            if hasattr(snake, "body") and not snake.body.alive:
+                continue
+            if hasattr(snake, "respawn_timer") and snake.respawn_timer.is_respawning:
+                continue
+            if not hasattr(snake, "position"):
+                continue
+
+            head_x = snake.position.x
+            head_y = snake.position.y
+
+            # check collision with other snakes
+            for other_id, other_snake in snake_list:
+                if snake_id == other_id:
+                    continue  # don't check against self
+
+                # skip if other snake is not alive or respawning
+                if hasattr(other_snake, "body") and not other_snake.body.alive:
+                    continue
+                if (
+                    hasattr(other_snake, "respawn_timer")
+                    and other_snake.respawn_timer.is_respawning
+                ):
+                    continue
+
+                # check collision with other snake's head
+                if hasattr(other_snake, "position"):
+                    if head_x == other_snake.position.x and head_y == other_snake.position.y:
+                        # head-to-head collision - both snakes die
+                        self._handle_snake_death(world, snake, "Player collision")
+                        self._handle_snake_death(world, other_snake, "Player collision")
+                        return
+
+                # check collision with other snake's body
+                if hasattr(other_snake, "body"):
+                    for segment in other_snake.body.segments:
+                        if head_x == segment.x and head_y == segment.y:
+                            # this snake hit the other snake's body
+                            self._handle_snake_death(world, snake, "Player collision")
+                            return
 
     def _check_obstacle_collision(self, world: World) -> bool:
         """Check collision with obstacles.
@@ -838,6 +908,57 @@ class CollisionSystem(BaseSystem):
             self._game_over_service.handle_death(world, reason)
         else:
             print(f"☠️ DEATH CAUSE: {reason} (Service missing)")
+
+    def _handle_snake_death(self, world: World, snake, reason: str) -> None:
+        """Handle death of a specific snake in PvP mode.
+
+        Args:
+            world: ECS world
+            snake: Snake entity that died
+            reason: Death reason
+        """
+        # check if snake has lives component (PvP mode)
+        if not hasattr(snake, "lives") or not hasattr(snake, "respawn_timer"):
+            # not in PvP mode, use normal death handling
+            self._handle_death(world, reason)
+            return
+
+        # play death sound
+        if self._audio_service:
+            self._audio_service.play_sound("assets/sound/gameover.wav")
+
+        # decrease lives
+        snake.lives.remaining -= 1
+
+        player_name = f"Player {snake.player_id.player_number}" if hasattr(snake, "player_id") else "Snake"
+        print(f"☠️ {player_name} died: {reason}. Lives remaining: {snake.lives.remaining}")
+
+        # check if snake has lives left
+        if snake.lives.remaining <= 0:
+            # no lives left for this snake
+            snake.body.alive = False
+            print(f"☠️ {player_name} has no lives left!")
+            
+            # check if all snakes are dead
+            from ecs.entities.entity import EntityType
+            snakes = world.registry.query_by_type(EntityType.SNAKE)
+            winner = None
+            for _, s in snakes.items():
+                if hasattr(s, "lives") and s.lives.remaining > 0:
+                    if hasattr(s, "player_id"):
+                        winner = s.player_id.player_number
+                    break
+            
+            if winner:
+                # game over - we have a winner
+                self._handle_death(world, f"Player {winner} wins!")
+            else:
+                # all snakes dead
+                self._handle_death(world, "Draw! All players eliminated")
+        else:
+            # trigger respawn
+            if self._respawn_system:
+                self._respawn_system.trigger_respawn(snake)
 
     def _check_board_fill_victory(self, world: World) -> bool:
         """Check if snake has filled the entire board (victory for Classic mode).

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -28,7 +28,10 @@ This system detects collisions between the snake and:
 Follows proper ECS architecture by querying world directly.
 """
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ecs.systems.respawn import RespawnSystem
 
 from ecs.systems.base_system import BaseSystem
 from ecs.world import World
@@ -571,7 +574,10 @@ class CollisionSystem(BaseSystem):
 
                 # check collision with other snake's head
                 if hasattr(other_snake, "position"):
-                    if head_x == other_snake.position.x and head_y == other_snake.position.y:
+                    if (
+                        head_x == other_snake.position.x
+                        and head_y == other_snake.position.y
+                    ):
                         # head-to-head collision - both snakes die
                         self._handle_snake_death(world, snake, "Player collision")
                         self._handle_snake_death(world, other_snake, "Player collision")
@@ -1096,16 +1102,17 @@ class CollisionSystem(BaseSystem):
 
     def _determine_winner_by_score(self, world: World) -> int | None:
         """Determine the winner based on final score (points - deaths).
-        
+
         Args:
             world: ECS world
-            
+
         Returns:
             Player number of the winner, or None if it's a draw
         """
         from ecs.entities.entity import EntityType
+
         snakes = world.registry.query_by_type(EntityType.SNAKE)
-        
+
         player_scores = []
         for _, snake in snakes.items():
             if hasattr(snake, "player_id") and hasattr(snake, "lives"):
@@ -1114,23 +1121,23 @@ class CollisionSystem(BaseSystem):
                 deaths = 3 - snake.lives.remaining
                 final_score = points - deaths
                 player_scores.append((player_num, final_score))
-        
+
         if not player_scores:
             return None
-        
+
         # Sort by final score (descending)
         player_scores.sort(key=lambda x: x[1], reverse=True)
-        
+
         # Check if there's a clear winner (no tie)
         if len(player_scores) == 1:
             return player_scores[0][0]
-        
+
         if player_scores[0][1] > player_scores[1][1]:
             return player_scores[0][0]
-        
+
         # It's a tie
         return None
-    
+
     def _handle_snake_death(self, world: World, snake, reason: str) -> None:
         """Handle death of a specific snake in PvP mode.
 
@@ -1152,29 +1159,36 @@ class CollisionSystem(BaseSystem):
         # decrease lives
         snake.lives.remaining -= 1
 
-        player_name = f"Player {snake.player_id.player_number}" if hasattr(snake, "player_id") else "Snake"
-        print(f"☠️ {player_name} died: {reason}. Lives remaining: {snake.lives.remaining}")
+        player_name = (
+            f"Player {snake.player_id.player_number}"
+            if hasattr(snake, "player_id")
+            else "Snake"
+        )
+        print(
+            f"☠️ {player_name} died: {reason}. Lives remaining: {snake.lives.remaining}"
+        )
 
         # check if snake has lives left
         if snake.lives.remaining <= 0:
             # no lives left for this snake
             snake.body.alive = False
             print(f"☠️ {player_name} has no lives left!")
-            
+
             # check if all snakes are dead or only one remains
             from ecs.entities.entity import EntityType
+
             snakes = world.registry.query_by_type(EntityType.SNAKE)
             alive_count = 0
             alive_snakes = []
             all_dead = True
-            
+
             for _, s in snakes.items():
                 if hasattr(s, "lives"):
                     if s.lives.remaining > 0:
                         alive_count += 1
                         all_dead = False
                         alive_snakes.append(s)
-            
+
             # Determine game over condition
             if all_dead:
                 # All snakes dead - determine winner by score

--- a/src/ecs/systems/collision.py
+++ b/src/ecs/systems/collision.py
@@ -1182,12 +1182,15 @@ class CollisionSystem(BaseSystem):
                 if winner:
                     self._handle_death(world, f"Player {winner} WINS!!")
                 else:
-                    self._handle_death(world, "Draw! All players eliminated")
+                    self._handle_death(world, "DRAW!! Tied Score")
             elif alive_count == 1:
                 # One survivor - determine winner by score
                 winner = self._determine_winner_by_score(world)
                 if winner:
                     self._handle_death(world, f"Player {winner} WINS!!")
+                else:
+                    # Tie in score, no clear winner
+                    self._handle_death(world, "DRAW!! Tied Score")
             # If alive_count > 1, game continues with remaining players
         else:
             # trigger respawn

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -151,7 +151,9 @@ class InputSystem(BaseSystem):
         if game_state:
             game_state.next_scene = "menu"
 
-    def _buffer_direction(self, world: World, dx: int, dy: int, player_id: Optional[int] = None) -> None:
+    def _buffer_direction(
+        self, world: World, dx: int, dy: int, player_id: Optional[int] = None
+    ) -> None:
         """Append a new direction to the snake's input buffer if valid.
 
         This method ensures that rapid direction changes are stored in order
@@ -169,7 +171,7 @@ class InputSystem(BaseSystem):
             snake = self._get_snake_by_player_id(world, player_id)
         else:
             snake = self._get_snake_entity(world)
-        
+
         if not snake:
             return
 
@@ -313,7 +315,10 @@ class InputSystem(BaseSystem):
 
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
-            if hasattr(snake, "player_id") and snake.player_id.player_number == player_id:
+            if (
+                hasattr(snake, "player_id")
+                and snake.player_id.player_number == player_id
+            ):
                 return snake
         return None
 

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -168,7 +168,7 @@ class InputSystem(BaseSystem):
         if self._game_mode == PLAYER_VS_PLAYER_MODE_NAME and player_id is not None:
             snake = self._get_snake_by_player_id(world, player_id)
         else:
-            snake = self._get_snake_entity(world)
+        snake = self._get_snake_entity(world)
         
         if not snake:
             return
@@ -244,14 +244,14 @@ class InputSystem(BaseSystem):
                     self._buffer_direction(world, -1, 0, player_id=2)
             else:
                 # Single player mode (both WASD and arrows control the same snake)
-                if key in (pygame.K_DOWN, pygame.K_s):
-                    self._buffer_direction(world, 0, 1)
-                elif key in (pygame.K_UP, pygame.K_w):
-                    self._buffer_direction(world, 0, -1)
-                elif key in (pygame.K_RIGHT, pygame.K_d):
-                    self._buffer_direction(world, 1, 0)
-                elif key in (pygame.K_LEFT, pygame.K_a):
-                    self._buffer_direction(world, -1, 0)
+            if key in (pygame.K_DOWN, pygame.K_s):
+                self._buffer_direction(world, 0, 1)
+            elif key in (pygame.K_UP, pygame.K_w):
+                self._buffer_direction(world, 0, -1)
+            elif key in (pygame.K_RIGHT, pygame.K_d):
+                self._buffer_direction(world, 1, 0)
+            elif key in (pygame.K_LEFT, pygame.K_a):
+                self._buffer_direction(world, -1, 0)
 
         # control keys
         if key == pygame.K_q:
@@ -314,7 +314,7 @@ class InputSystem(BaseSystem):
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
             if hasattr(snake, "player_id") and snake.player_id.player_number == player_id:
-                return snake
+            return snake
         return None
 
     def _get_game_state(self, world: World):

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -168,7 +168,7 @@ class InputSystem(BaseSystem):
         if self._game_mode == PLAYER_VS_PLAYER_MODE_NAME and player_id is not None:
             snake = self._get_snake_by_player_id(world, player_id)
         else:
-        snake = self._get_snake_entity(world)
+            snake = self._get_snake_entity(world)
         
         if not snake:
             return
@@ -244,14 +244,14 @@ class InputSystem(BaseSystem):
                     self._buffer_direction(world, -1, 0, player_id=2)
             else:
                 # Single player mode (both WASD and arrows control the same snake)
-            if key in (pygame.K_DOWN, pygame.K_s):
-                self._buffer_direction(world, 0, 1)
-            elif key in (pygame.K_UP, pygame.K_w):
-                self._buffer_direction(world, 0, -1)
-            elif key in (pygame.K_RIGHT, pygame.K_d):
-                self._buffer_direction(world, 1, 0)
-            elif key in (pygame.K_LEFT, pygame.K_a):
-                self._buffer_direction(world, -1, 0)
+                if key in (pygame.K_DOWN, pygame.K_s):
+                    self._buffer_direction(world, 0, 1)
+                elif key in (pygame.K_UP, pygame.K_w):
+                    self._buffer_direction(world, 0, -1)
+                elif key in (pygame.K_RIGHT, pygame.K_d):
+                    self._buffer_direction(world, 1, 0)
+                elif key in (pygame.K_LEFT, pygame.K_a):
+                    self._buffer_direction(world, -1, 0)
 
         # control keys
         if key == pygame.K_q:
@@ -314,7 +314,7 @@ class InputSystem(BaseSystem):
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
             if hasattr(snake, "player_id") and snake.player_id.player_number == player_id:
-            return snake
+                return snake
         return None
 
     def _get_game_state(self, world: World):

--- a/src/ecs/systems/input.py
+++ b/src/ecs/systems/input.py
@@ -29,6 +29,7 @@ import pygame
 
 from ecs.systems.base_system import BaseSystem
 from ecs.world import World
+from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
 
 
 class InputSystem(BaseSystem):
@@ -150,7 +151,7 @@ class InputSystem(BaseSystem):
         if game_state:
             game_state.next_scene = "menu"
 
-    def _buffer_direction(self, world: World, dx: int, dy: int) -> None:
+    def _buffer_direction(self, world: World, dx: int, dy: int, player_id: Optional[int] = None) -> None:
         """Append a new direction to the snake's input buffer if valid.
 
         This method ensures that rapid direction changes are stored in order
@@ -161,8 +162,14 @@ class InputSystem(BaseSystem):
             world: ECS world containing the snake entity
             dx: Horizontal component of the direction (-1, 0, 1)
             dy: Vertical component of the direction (-1, 0, 1)
+            player_id: Player ID (1 or 2) for PvP mode, None for single player
         """
-        snake = self._get_snake_entity(world)
+        # Get the appropriate snake based on mode
+        if self._game_mode == PLAYER_VS_PLAYER_MODE_NAME and player_id is not None:
+            snake = self._get_snake_by_player_id(world, player_id)
+        else:
+            snake = self._get_snake_entity(world)
+        
         if not snake:
             return
 
@@ -216,14 +223,35 @@ class InputSystem(BaseSystem):
         from game.game_modes_registry import AUTOPLAY_MODE_NAME
 
         if self._game_mode != AUTOPLAY_MODE_NAME:
-            if key in (pygame.K_DOWN, pygame.K_s):
-                self._buffer_direction(world, 0, 1)
-            elif key in (pygame.K_UP, pygame.K_w):
-                self._buffer_direction(world, 0, -1)
-            elif key in (pygame.K_RIGHT, pygame.K_d):
-                self._buffer_direction(world, 1, 0)
-            elif key in (pygame.K_LEFT, pygame.K_a):
-                self._buffer_direction(world, -1, 0)
+            if self._game_mode == PLAYER_VS_PLAYER_MODE_NAME:
+                # Player 1 controls (WASD)
+                if key == pygame.K_s:
+                    self._buffer_direction(world, 0, 1, player_id=1)
+                elif key == pygame.K_w:
+                    self._buffer_direction(world, 0, -1, player_id=1)
+                elif key == pygame.K_d:
+                    self._buffer_direction(world, 1, 0, player_id=1)
+                elif key == pygame.K_a:
+                    self._buffer_direction(world, -1, 0, player_id=1)
+                # Player 2 controls (Arrow keys)
+                elif key == pygame.K_DOWN:
+                    self._buffer_direction(world, 0, 1, player_id=2)
+                elif key == pygame.K_UP:
+                    self._buffer_direction(world, 0, -1, player_id=2)
+                elif key == pygame.K_RIGHT:
+                    self._buffer_direction(world, 1, 0, player_id=2)
+                elif key == pygame.K_LEFT:
+                    self._buffer_direction(world, -1, 0, player_id=2)
+            else:
+                # Single player mode (both WASD and arrows control the same snake)
+                if key in (pygame.K_DOWN, pygame.K_s):
+                    self._buffer_direction(world, 0, 1)
+                elif key in (pygame.K_UP, pygame.K_w):
+                    self._buffer_direction(world, 0, -1)
+                elif key in (pygame.K_RIGHT, pygame.K_d):
+                    self._buffer_direction(world, 1, 0)
+                elif key in (pygame.K_LEFT, pygame.K_a):
+                    self._buffer_direction(world, -1, 0)
 
         # control keys
         if key == pygame.K_q:
@@ -269,6 +297,24 @@ class InputSystem(BaseSystem):
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
             return snake
+        return None
+
+    def _get_snake_by_player_id(self, world: World, player_id: int):
+        """Get a specific snake by player ID (for PvP mode).
+
+        Args:
+            world: ECS world
+            player_id: Player number (1 or 2)
+
+        Returns:
+            Snake entity or None if not found
+        """
+        from ecs.entities.entity import EntityType
+
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for _, snake in snakes.items():
+            if hasattr(snake, "player_id") and snake.player_id.player_number == player_id:
+                return snake
         return None
 
     def _get_game_state(self, world: World):

--- a/src/ecs/systems/respawn.py
+++ b/src/ecs/systems/respawn.py
@@ -66,7 +66,8 @@ class RespawnSystem(BaseSystem):
 
         # query all snakes with respawn timers
         snakes = world.registry.query_by_type(EntityType.SNAKE)
-
+        
+        respawning_count = 0
         for snake_id, snake in snakes.items():
             if not hasattr(snake, "respawn_timer") or not hasattr(snake, "lives"):
                 continue
@@ -76,10 +77,18 @@ class RespawnSystem(BaseSystem):
 
             # if snake is respawning, count down the timer
             if respawn_timer.is_respawning:
+                respawning_count += 1
+                player_name = f"Player {snake.player_id.player_number}" if hasattr(snake, "player_id") else f"Snake {snake_id}"
+                
+                old_time = respawn_timer.time_remaining_ms
                 respawn_timer.time_remaining_ms -= dt_ms
+                
+                if respawning_count == 1:  # Only print for first respawning snake to avoid spam
+                    print(f"{player_name} respawn timer: {old_time:.0f}ms -> {respawn_timer.time_remaining_ms:.0f}ms")
 
                 # time to respawn?
                 if respawn_timer.time_remaining_ms <= 0:
+                    print(f"Timer expired for {player_name}! Respawning now...")
                     self._respawn_snake(world, snake_id, snake)
                     respawn_timer.is_respawning = False
                     respawn_timer.time_remaining_ms = 0.0
@@ -99,14 +108,20 @@ class RespawnSystem(BaseSystem):
             snake_id: Entity ID of the snake
             snake: Snake entity
         """
+        print(f"Respawning snake {snake_id}...")
+        
         # find a valid spawn position
         grid = self._get_grid(world)
         if not grid:
+            print("No grid found!")
             return
 
         spawn_pos = self._find_valid_spawn_position(world, grid)
         if not spawn_pos:
+            print("No valid spawn position found!")
             return
+
+        print(f"Spawning at position: {spawn_pos}")
 
         # reset snake position
         if hasattr(snake, "position"):
@@ -115,11 +130,11 @@ class RespawnSystem(BaseSystem):
             snake.position.prev_x = spawn_pos[0]
             snake.position.prev_y = spawn_pos[1]
 
-        # reset snake body
+        # reset snake body - IMPORTANT: Set alive to True
         if hasattr(snake, "body"):
             snake.body.segments = []
             snake.body.size = 1
-            snake.body.alive = True
+            snake.body.alive = True  # Make sure snake is alive
             snake.body.pending_growth = 0
 
         # reset velocity to a random direction
@@ -128,6 +143,8 @@ class RespawnSystem(BaseSystem):
             dx, dy = random.choice(directions)
             snake.velocity.dx = dx
             snake.velocity.dy = dy
+            
+        print(f"Snake respawned successfully at {spawn_pos}")
 
     def _get_grid(self, world: World):
         """Get the grid component."""
@@ -208,10 +225,14 @@ class RespawnSystem(BaseSystem):
         if hasattr(snake, "respawn_timer") and hasattr(snake, "lives"):
             # check if snake has lives left
             if snake.lives.remaining > 0:
+                player_name = f"Player {snake.player_id.player_number}" if hasattr(snake, "player_id") else "Snake"
+                print(f"Triggering respawn for {player_name}. Timer: {self.RESPAWN_TIME_MS}ms")
+                
                 snake.respawn_timer.is_respawning = True
                 snake.respawn_timer.time_remaining_ms = self.RESPAWN_TIME_MS
 
                 # make snake invisible/inactive during respawn
                 if hasattr(snake, "body"):
                     snake.body.alive = False
+                    print(f"{player_name} set to not alive during respawn countdown")
 

--- a/src/ecs/systems/respawn.py
+++ b/src/ecs/systems/respawn.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Respawn system for handling snake respawns in PvP mode."""
+
+import random
+from typing import Optional
+
+from ecs.systems.base_system import BaseSystem
+from ecs.world import World
+from ecs.entities.entity import EntityType
+from ecs.components.position import Position
+from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
+
+
+class RespawnSystem(BaseSystem):
+    """System for handling snake respawns after death.
+
+    Reads: RespawnTimer, Lives, Position, SnakeBody, GameState
+    Writes: RespawnTimer, Position, SnakeBody, Velocity
+    Queries:
+        - Snake entities (EntityType.SNAKE)
+        - GameState entity (component "game_state")
+
+    Responsibilities:
+    - Count down respawn timers
+    - Respawn snakes at valid positions after timer expires
+    - Reset snake state (position, body, velocity)
+    """
+
+    RESPAWN_TIME_MS = 3000.0  # 3 seconds
+
+    def __init__(self):
+        """Initialize the RespawnSystem."""
+        pass
+
+    def update(self, world: World) -> None:
+        """Update respawn timers and respawn snakes when ready.
+
+        Args:
+            world: ECS world to query entities
+        """
+        # assume 16ms per frame (60 FPS)
+        dt_ms = 16.0
+        
+        # only run in Player vs Player mode
+        game_state = self._get_game_state(world)
+        if not game_state or game_state.game_mode != PLAYER_VS_PLAYER_MODE_NAME:
+            return
+
+        # query all snakes with respawn timers
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+
+        for snake_id, snake in snakes.items():
+            if not hasattr(snake, "respawn_timer") or not hasattr(snake, "lives"):
+                continue
+
+            respawn_timer = snake.respawn_timer
+            lives = snake.lives
+
+            # if snake is respawning, count down the timer
+            if respawn_timer.is_respawning:
+                respawn_timer.time_remaining_ms -= dt_ms
+
+                # time to respawn?
+                if respawn_timer.time_remaining_ms <= 0:
+                    self._respawn_snake(world, snake_id, snake)
+                    respawn_timer.is_respawning = False
+                    respawn_timer.time_remaining_ms = 0.0
+
+    def _get_game_state(self, world: World):
+        """Get the game state entity."""
+        game_states = world.registry.query_by_component("game_state")
+        for _, entity in game_states.items():
+            return entity.game_state
+        return None
+
+    def _respawn_snake(self, world: World, snake_id: int, snake) -> None:
+        """Respawn a snake at a valid position.
+
+        Args:
+            world: ECS world
+            snake_id: Entity ID of the snake
+            snake: Snake entity
+        """
+        # find a valid spawn position
+        grid = self._get_grid(world)
+        if not grid:
+            return
+
+        spawn_pos = self._find_valid_spawn_position(world, grid)
+        if not spawn_pos:
+            return
+
+        # reset snake position
+        if hasattr(snake, "position"):
+            snake.position.x = spawn_pos[0]
+            snake.position.y = spawn_pos[1]
+            snake.position.prev_x = spawn_pos[0]
+            snake.position.prev_y = spawn_pos[1]
+
+        # reset snake body
+        if hasattr(snake, "body"):
+            snake.body.segments = []
+            snake.body.size = 1
+            snake.body.alive = True
+            snake.body.pending_growth = 0
+
+        # reset velocity to a random direction
+        if hasattr(snake, "velocity"):
+            directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+            dx, dy = random.choice(directions)
+            snake.velocity.dx = dx
+            snake.velocity.dy = dy
+
+    def _get_grid(self, world: World):
+        """Get the grid component."""
+        grids = world.registry.query_by_component("grid")
+        for _, entity in grids.items():
+            return entity.grid
+        return None
+
+    def _find_valid_spawn_position(
+        self, world: World, grid
+    ) -> Optional[tuple[int, int]]:
+        """Find a valid position to spawn a snake.
+
+        Args:
+            world: ECS world
+            grid: Grid component
+
+        Returns:
+            Tuple of (x, y) coordinates, or None if no valid position found
+        """
+        # get all occupied positions
+        occupied = set()
+
+        # add snake positions
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for _, snake in snakes.items():
+            if hasattr(snake, "position"):
+                occupied.add((snake.position.x, snake.position.y))
+            if hasattr(snake, "body"):
+                for segment in snake.body.segments:
+                    occupied.add((segment.x, segment.y))
+
+        # add apple positions
+        apples = world.registry.query_by_type(EntityType.APPLE)
+        for _, apple in apples.items():
+            if hasattr(apple, "position"):
+                occupied.add((apple.position.x, apple.position.y))
+
+        # add obstacle positions
+        obstacles = world.registry.query_by_type(EntityType.OBSTACLE)
+        for _, obstacle in obstacles.items():
+            if hasattr(obstacle, "position"):
+                occupied.add((obstacle.position.x, obstacle.position.y))
+
+        # try to find a valid position (with some margin from edges)
+        margin = 2
+        attempts = 0
+        max_attempts = 100
+
+        while attempts < max_attempts:
+            x = random.randint(margin, grid.width - margin - 1)
+            y = random.randint(margin, grid.height - margin - 1)
+
+            if (x, y) not in occupied:
+                return (x, y)
+
+            attempts += 1
+
+        # if we couldn't find a position with margin, try anywhere
+        attempts = 0
+        while attempts < max_attempts:
+            x = random.randint(0, grid.width - 1)
+            y = random.randint(0, grid.height - 1)
+
+            if (x, y) not in occupied:
+                return (x, y)
+
+            attempts += 1
+
+        return None
+
+    def trigger_respawn(self, snake) -> None:
+        """Trigger a respawn for a snake.
+
+        Args:
+            snake: Snake entity to respawn
+        """
+        if hasattr(snake, "respawn_timer") and hasattr(snake, "lives"):
+            # check if snake has lives left
+            if snake.lives.remaining > 0:
+                snake.respawn_timer.is_respawning = True
+                snake.respawn_timer.time_remaining_ms = self.RESPAWN_TIME_MS
+
+                # make snake invisible/inactive during respawn
+                if hasattr(snake, "body"):
+                    snake.body.alive = False
+

--- a/src/ecs/systems/respawn.py
+++ b/src/ecs/systems/respawn.py
@@ -147,20 +147,20 @@ class RespawnSystem(BaseSystem):
         print(f"Snake respawned successfully at {spawn_pos}")
 
     def _get_grid(self, world: World):
-        """Get the grid component."""
-        grids = world.registry.query_by_component("grid")
-        for _, entity in grids.items():
-            return entity.grid
+        """Get the grid component from world.board."""
+        # Use world.board directly instead of querying components
+        if hasattr(world, "board"):
+            return world.board
         return None
 
     def _find_valid_spawn_position(
-        self, world: World, grid
+        self, world: World, board
     ) -> Optional[tuple[int, int]]:
         """Find a valid position to spawn a snake.
 
         Args:
             world: ECS world
-            grid: Grid component
+            board: Board object with width and height
 
         Returns:
             Tuple of (x, y) coordinates, or None if no valid position found
@@ -171,11 +171,11 @@ class RespawnSystem(BaseSystem):
         # add snake positions
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
-            if hasattr(snake, "position"):
+            if hasattr(snake, "position") and hasattr(snake, "body") and snake.body.alive:
                 occupied.add((snake.position.x, snake.position.y))
-            if hasattr(snake, "body"):
-                for segment in snake.body.segments:
-                    occupied.add((segment.x, segment.y))
+                if hasattr(snake, "body"):
+                    for segment in snake.body.segments:
+                        occupied.add((segment.x, segment.y))
 
         # add apple positions
         apples = world.registry.query_by_type(EntityType.APPLE)
@@ -195,8 +195,8 @@ class RespawnSystem(BaseSystem):
         max_attempts = 100
 
         while attempts < max_attempts:
-            x = random.randint(margin, grid.width - margin - 1)
-            y = random.randint(margin, grid.height - margin - 1)
+            x = random.randint(margin, board.width - margin - 1)
+            y = random.randint(margin, board.height - margin - 1)
 
             if (x, y) not in occupied:
                 return (x, y)
@@ -206,8 +206,8 @@ class RespawnSystem(BaseSystem):
         # if we couldn't find a position with margin, try anywhere
         attempts = 0
         while attempts < max_attempts:
-            x = random.randint(0, grid.width - 1)
-            y = random.randint(0, grid.height - 1)
+            x = random.randint(0, board.width - 1)
+            y = random.randint(0, board.height - 1)
 
             if (x, y) not in occupied:
                 return (x, y)

--- a/src/ecs/systems/respawn.py
+++ b/src/ecs/systems/respawn.py
@@ -25,7 +25,6 @@ from typing import Optional
 from ecs.systems.base_system import BaseSystem
 from ecs.world import World
 from ecs.entities.entity import EntityType
-from ecs.components.position import Position
 from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
 
 
@@ -58,7 +57,7 @@ class RespawnSystem(BaseSystem):
         """
         # assume 16ms per frame (60 FPS)
         dt_ms = 16.0
-        
+
         # only run in Player vs Player mode
         game_state = self._get_game_state(world)
         if not game_state or game_state.game_mode != PLAYER_VS_PLAYER_MODE_NAME:
@@ -66,25 +65,32 @@ class RespawnSystem(BaseSystem):
 
         # query all snakes with respawn timers
         snakes = world.registry.query_by_type(EntityType.SNAKE)
-        
+
         respawning_count = 0
         for snake_id, snake in snakes.items():
             if not hasattr(snake, "respawn_timer") or not hasattr(snake, "lives"):
                 continue
 
             respawn_timer = snake.respawn_timer
-            lives = snake.lives
 
             # if snake is respawning, count down the timer
             if respawn_timer.is_respawning:
                 respawning_count += 1
-                player_name = f"Player {snake.player_id.player_number}" if hasattr(snake, "player_id") else f"Snake {snake_id}"
-                
+                player_name = (
+                    f"Player {snake.player_id.player_number}"
+                    if hasattr(snake, "player_id")
+                    else f"Snake {snake_id}"
+                )
+
                 old_time = respawn_timer.time_remaining_ms
                 respawn_timer.time_remaining_ms -= dt_ms
-                
-                if respawning_count == 1:  # Only print for first respawning snake to avoid spam
-                    print(f"{player_name} respawn timer: {old_time:.0f}ms -> {respawn_timer.time_remaining_ms:.0f}ms")
+
+                if (
+                    respawning_count == 1
+                ):  # Only print for first respawning snake to avoid spam
+                    print(
+                        f"{player_name} respawn timer: {old_time:.0f}ms -> {respawn_timer.time_remaining_ms:.0f}ms"
+                    )
 
                 # time to respawn?
                 if respawn_timer.time_remaining_ms <= 0:
@@ -109,7 +115,7 @@ class RespawnSystem(BaseSystem):
             snake: Snake entity
         """
         print(f"Respawning snake {snake_id}...")
-        
+
         # find a valid spawn position
         grid = self._get_grid(world)
         if not grid:
@@ -143,7 +149,7 @@ class RespawnSystem(BaseSystem):
             dx, dy = random.choice(directions)
             snake.velocity.dx = dx
             snake.velocity.dy = dy
-            
+
         print(f"Snake respawned successfully at {spawn_pos}")
 
     def _get_grid(self, world: World):
@@ -171,7 +177,11 @@ class RespawnSystem(BaseSystem):
         # add snake positions
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
-            if hasattr(snake, "position") and hasattr(snake, "body") and snake.body.alive:
+            if (
+                hasattr(snake, "position")
+                and hasattr(snake, "body")
+                and snake.body.alive
+            ):
                 occupied.add((snake.position.x, snake.position.y))
                 if hasattr(snake, "body"):
                     for segment in snake.body.segments:
@@ -225,9 +235,15 @@ class RespawnSystem(BaseSystem):
         if hasattr(snake, "respawn_timer") and hasattr(snake, "lives"):
             # check if snake has lives left
             if snake.lives.remaining > 0:
-                player_name = f"Player {snake.player_id.player_number}" if hasattr(snake, "player_id") else "Snake"
-                print(f"Triggering respawn for {player_name}. Timer: {self.RESPAWN_TIME_MS}ms")
-                
+                player_name = (
+                    f"Player {snake.player_id.player_number}"
+                    if hasattr(snake, "player_id")
+                    else "Snake"
+                )
+                print(
+                    f"Triggering respawn for {player_name}. Timer: {self.RESPAWN_TIME_MS}ms"
+                )
+
                 snake.respawn_timer.is_respawning = True
                 snake.respawn_timer.time_remaining_ms = self.RESPAWN_TIME_MS
 
@@ -235,4 +251,3 @@ class RespawnSystem(BaseSystem):
                 if hasattr(snake, "body"):
                     snake.body.alive = False
                     print(f"{player_name} set to not alive during respawn countdown")
-

--- a/src/ecs/systems/settings_apply.py
+++ b/src/ecs/systems/settings_apply.py
@@ -212,11 +212,13 @@ class SettingsApplySystem(BaseSystem):
         """
         current_palette = self._get_current_palette_key()
         current_p2_palette = self._get_current_player2_palette_key()
-        
+
         # Check if either player's palette changed
-        palette_changed = (current_palette != self._previous_palette or 
-                          current_p2_palette != self._previous_player2_palette)
-        
+        palette_changed = (
+            current_palette != self._previous_palette
+            or current_p2_palette != self._previous_player2_palette
+        )
+
         if not palette_changed:
             return
 
@@ -224,7 +226,7 @@ class SettingsApplySystem(BaseSystem):
         self._apply_palette_change(world)
         self._previous_palette = current_palette
         self._previous_player2_palette = current_p2_palette
-    
+
     def _get_current_player2_palette_key(self) -> str:
         """Get a unique key representing current player 2 palette.
 
@@ -242,6 +244,7 @@ class SettingsApplySystem(BaseSystem):
         """
         # Check if we're in PvP mode
         from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
+
         game_states = world.registry.query_by_component("game_state")
         is_pvp = False
         if game_states:
@@ -275,27 +278,29 @@ class SettingsApplySystem(BaseSystem):
                     # update both head and tail colors in renderable
                     snake.renderable.color = head_color
                     snake.renderable.secondary_color = tail_color
-                    print(f"Applied palette: head={head_color_hex}, tail={tail_color_hex}")
+                    print(
+                        f"Applied palette: head={head_color_hex}, tail={tail_color_hex}"
+                    )
                     break
-    
+
     def _apply_player_colors(self, world: World) -> None:
         """Apply colors to both players in PvP mode.
-        
+
         Args:
             world: ECS world instance
         """
         from core.types.color import Color
-        
+
         # Get colors for both players
         p1_colors = self._settings.get_snake_colors()
         p2_colors = self._settings.get_player2_colors()
-        
+
         # Find and update each player's snake
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
             if not hasattr(snake, "player_id") or not hasattr(snake, "renderable"):
                 continue
-            
+
             player_num = snake.player_id.player_number
             if player_num == 1:
                 colors = p1_colors
@@ -303,19 +308,21 @@ class SettingsApplySystem(BaseSystem):
                 colors = p2_colors
             else:
                 continue
-            
+
             head_color_hex = colors.get("head")
             tail_color_hex = colors.get("tail")
-            
+
             head_color = Color.from_hex(head_color_hex)
             if tail_color_hex == "#rainbow":
                 tail_color = Color(0, 0, 0)
             else:
                 tail_color = Color.from_hex(tail_color_hex)
-            
+
             snake.renderable.color = head_color
             snake.renderable.secondary_color = tail_color
-            print(f"Applied P{player_num} palette: head={head_color_hex}, tail={tail_color_hex}")
+            print(
+                f"Applied P{player_num} palette: head={head_color_hex}, tail={tail_color_hex}"
+            )
 
     def _get_current_board_palette_key(self) -> str:
         """Get a unique key representing current board palette colors.

--- a/src/ecs/systems/settings_apply.py
+++ b/src/ecs/systems/settings_apply.py
@@ -65,6 +65,7 @@ class SettingsApplySystem(BaseSystem):
         # track previous settings to detect changes
         self._previous_cells_per_side = None
         self._previous_palette = None
+        self._previous_player2_palette = None
         self._previous_board_palette = None
         self._previous_initial_speed = None
         self._previous_max_speed = None
@@ -210,12 +211,28 @@ class SettingsApplySystem(BaseSystem):
             world: ECS world instance
         """
         current_palette = self._get_current_palette_key()
-        if current_palette == self._previous_palette:
+        current_p2_palette = self._get_current_player2_palette_key()
+        
+        # Check if either player's palette changed
+        palette_changed = (current_palette != self._previous_palette or 
+                          current_p2_palette != self._previous_player2_palette)
+        
+        if not palette_changed:
             return
 
         # palette changed, apply it
         self._apply_palette_change(world)
         self._previous_palette = current_palette
+        self._previous_player2_palette = current_p2_palette
+    
+    def _get_current_player2_palette_key(self) -> str:
+        """Get a unique key representing current player 2 palette.
+
+        Returns:
+            String key combining head and tail colors
+        """
+        p2_colors = self._settings.get_player2_colors()
+        return f"{p2_colors['head']}_{p2_colors['tail']}"
 
     def _apply_palette_change(self, world: World) -> None:
         """Apply palette change to snake entity.
@@ -223,31 +240,82 @@ class SettingsApplySystem(BaseSystem):
         Args:
             world: ECS world instance
         """
-        # get the colors from the current palette
-        snake_colors = self._settings.get_snake_colors()
-        head_color_hex = snake_colors.get("head")
-        tail_color_hex = snake_colors.get("tail")
+        # Check if we're in PvP mode
+        from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
+        game_states = world.registry.query_by_component("game_state")
+        is_pvp = False
+        if game_states:
+            game_state = list(game_states.values())[0].game_state
+            is_pvp = game_state.game_mode == PLAYER_VS_PLAYER_MODE_NAME
 
-        # convert hex colors to Color objects
-        from core.types.color import Color
-
-        head_color = Color.from_hex(head_color_hex)
-        # Check for rainbow mode (special marker in tail color)
-        if tail_color_hex == "#rainbow":
-            # Rainbow mode: use black (0,0,0) as marker for render system
-            tail_color = Color(0, 0, 0)
+        if is_pvp:
+            # Apply colors to both players
+            self._apply_player_colors(world)
         else:
-            tail_color = Color.from_hex(tail_color_hex)
+            # Single player mode - apply to the one snake
+            snake_colors = self._settings.get_snake_colors()
+            head_color_hex = snake_colors.get("head")
+            tail_color_hex = snake_colors.get("tail")
 
-        # find the snake entity and update its renderable colors
+            # convert hex colors to Color objects
+            from core.types.color import Color
+
+            head_color = Color.from_hex(head_color_hex)
+            # Check for rainbow mode (special marker in tail color)
+            if tail_color_hex == "#rainbow":
+                # Rainbow mode: use black (0,0,0) as marker for render system
+                tail_color = Color(0, 0, 0)
+            else:
+                tail_color = Color.from_hex(tail_color_hex)
+
+            # find the snake entity and update its renderable colors
+            snakes = world.registry.query_by_type(EntityType.SNAKE)
+            for _, snake in snakes.items():
+                if hasattr(snake, "renderable"):
+                    # update both head and tail colors in renderable
+                    snake.renderable.color = head_color
+                    snake.renderable.secondary_color = tail_color
+                    print(f"Applied palette: head={head_color_hex}, tail={tail_color_hex}")
+                    break
+    
+    def _apply_player_colors(self, world: World) -> None:
+        """Apply colors to both players in PvP mode.
+        
+        Args:
+            world: ECS world instance
+        """
+        from core.types.color import Color
+        
+        # Get colors for both players
+        p1_colors = self._settings.get_snake_colors()
+        p2_colors = self._settings.get_player2_colors()
+        
+        # Find and update each player's snake
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         for _, snake in snakes.items():
-            if hasattr(snake, "renderable"):
-                # update both head and tail colors in renderable
-                snake.renderable.color = head_color
-                snake.renderable.secondary_color = tail_color
-                print(f"Applied palette: head={head_color_hex}, tail={tail_color_hex}")
-                break
+            if not hasattr(snake, "player_id") or not hasattr(snake, "renderable"):
+                continue
+            
+            player_num = snake.player_id.player_number
+            if player_num == 1:
+                colors = p1_colors
+            elif player_num == 2:
+                colors = p2_colors
+            else:
+                continue
+            
+            head_color_hex = colors.get("head")
+            tail_color_hex = colors.get("tail")
+            
+            head_color = Color.from_hex(head_color_hex)
+            if tail_color_hex == "#rainbow":
+                tail_color = Color(0, 0, 0)
+            else:
+                tail_color = Color.from_hex(tail_color_hex)
+            
+            snake.renderable.color = head_color
+            snake.renderable.secondary_color = tail_color
+            print(f"Applied P{player_num} palette: head={head_color_hex}, tail={tail_color_hex}")
 
     def _get_current_board_palette_key(self) -> str:
         """Get a unique key representing current board palette colors.

--- a/src/ecs/systems/ui_render.py
+++ b/src/ecs/systems/ui_render.py
@@ -523,7 +523,9 @@ class UIRenderSystem(BaseSystem):
         # draw lives and scores for PvP mode
         self.draw_pvp_ui(world, surface_width, surface_height)
 
-    def draw_pvp_ui(self, world: World, surface_width: int, surface_height: int) -> None:
+    def draw_pvp_ui(
+        self, world: World, surface_width: int, surface_height: int
+    ) -> None:
         """Draw lives and scores for both players in PvP mode.
 
         Args:
@@ -543,7 +545,7 @@ class UIRenderSystem(BaseSystem):
         # query all snakes with player_id
         snakes = world.registry.query_by_type(EntityType.SNAKE)
         players = []
-        
+
         for snake_id, snake in snakes.items():
             if hasattr(snake, "player_id") and hasattr(snake, "lives"):
                 players.append(snake)
@@ -557,7 +559,9 @@ class UIRenderSystem(BaseSystem):
         # font for player info
         font_size = int(surface_width / 35)
         try:
-            player_font = pygame.font.Font("assets/font/GetVoIP-Grotesque.ttf", font_size)
+            player_font = pygame.font.Font(
+                "assets/font/GetVoIP-Grotesque.ttf", font_size
+            )
         except Exception:
             player_font = pygame.font.Font(None, font_size)
 
@@ -583,8 +587,10 @@ class UIRenderSystem(BaseSystem):
                 color = (100, 150, 255)
 
             # check if player is respawning
-            is_respawning = hasattr(player, "respawn_timer") and player.respawn_timer.is_respawning
-            
+            is_respawning = (
+                hasattr(player, "respawn_timer") and player.respawn_timer.is_respawning
+            )
+
             if is_respawning:
                 # show respawn timer
                 time_left = player.respawn_timer.time_remaining_ms / 1000.0
@@ -592,9 +598,9 @@ class UIRenderSystem(BaseSystem):
             else:
                 # show normal info
                 label = f"P{player_num}: {lives_remaining}♥ | {score} pts"
-            
+
             player_text = player_font.render(label, True, color)
-            
+
             if align == "right":
                 player_rect = player_text.get_rect()
                 player_rect.bottomright = (x_pos, bottom_y + font_size * 2)

--- a/src/ecs/systems/ui_render.py
+++ b/src/ecs/systems/ui_render.py
@@ -30,6 +30,7 @@ from ecs.entities.entity import EntityType
 from core.rendering.pygame_surface_renderer import RenderEnqueue
 from core.types.color import Color
 from game import constants
+from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
 
 
 class UIRenderSystem(BaseSystem):
@@ -518,3 +519,78 @@ class UIRenderSystem(BaseSystem):
         if self._settings:
             music_on = self._settings.get("background_music")
             self.draw_music_indicator(surface_width, surface_height, music_on)
+
+        # draw lives and scores for PvP mode
+        self.draw_pvp_ui(world, surface_width, surface_height)
+
+    def draw_pvp_ui(self, world: World, surface_width: int, surface_height: int) -> None:
+        """Draw lives and scores for both players in PvP mode.
+
+        Args:
+            world: Game world to query snakes
+            surface_width: Width of the surface
+            surface_height: Height of the surface
+        """
+        # only draw in PvP mode
+        game_states = world.registry.query_by_component("game_state")
+        if not game_states:
+            return
+
+        game_state = list(game_states.values())[0].game_state
+        if game_state.game_mode != PLAYER_VS_PLAYER_MODE_NAME:
+            return
+
+        # query all snakes with player_id
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        players = []
+        
+        for snake_id, snake in snakes.items():
+            if hasattr(snake, "player_id") and hasattr(snake, "lives"):
+                players.append(snake)
+
+        if not players:
+            return
+
+        # sort by player number
+        players.sort(key=lambda s: s.player_id.player_number)
+
+        # font for player info
+        font_size = int(surface_width / 35)
+        try:
+            player_font = pygame.font.Font("assets/font/GetVoIP-Grotesque.ttf", font_size)
+        except Exception:
+            player_font = pygame.font.Font(None, font_size)
+
+        # position in bottom corners
+        padding = int(surface_width * 0.02)
+        bottom_y = surface_height - padding - font_size * 2
+
+        for player in players:
+            player_num = player.player_id.player_number
+            lives_remaining = player.lives.remaining
+            score = player.player_id.score
+
+            # determine position and color
+            if player_num == 1:
+                # Player 1 - bottom left, green
+                x_pos = padding
+                align = "left"
+                color = (100, 255, 100)
+            else:
+                # Player 2 - bottom right, blue
+                x_pos = surface_width - padding
+                align = "right"
+                color = (100, 150, 255)
+
+            # render player info
+            label = f"P{player_num}: {lives_remaining}♥ | {score} pts"
+            player_text = player_font.render(label, True, color)
+            
+            if align == "right":
+                player_rect = player_text.get_rect()
+                player_rect.bottomright = (x_pos, bottom_y + font_size * 2)
+            else:
+                player_rect = player_text.get_rect()
+                player_rect.bottomleft = (x_pos, bottom_y + font_size * 2)
+
+            self._renderer.blit(player_text, player_rect)

--- a/src/ecs/systems/ui_render.py
+++ b/src/ecs/systems/ui_render.py
@@ -115,7 +115,7 @@ class UIRenderSystem(BaseSystem):
                 score_rect = score_text.get_rect()
                 score_rect.midleft = (padding + icon_size + 10, center_y)
             else:
-            score_rect = score_text.get_rect()
+                score_rect = score_text.get_rect()
                 score_rect.midleft = (padding, center_y)
 
             # blit score text

--- a/src/ecs/systems/ui_render.py
+++ b/src/ecs/systems/ui_render.py
@@ -582,8 +582,17 @@ class UIRenderSystem(BaseSystem):
                 align = "right"
                 color = (100, 150, 255)
 
-            # render player info
-            label = f"P{player_num}: {lives_remaining}♥ | {score} pts"
+            # check if player is respawning
+            is_respawning = hasattr(player, "respawn_timer") and player.respawn_timer.is_respawning
+            
+            if is_respawning:
+                # show respawn timer
+                time_left = player.respawn_timer.time_remaining_ms / 1000.0
+                label = f"P{player_num}: {lives_remaining}♥ | Respawning in {time_left:.1f}s"
+            else:
+                # show normal info
+                label = f"P{player_num}: {lives_remaining}♥ | {score} pts"
+            
             player_text = player_font.render(label, True, color)
             
             if align == "right":

--- a/src/ecs/systems/ui_render.py
+++ b/src/ecs/systems/ui_render.py
@@ -115,7 +115,7 @@ class UIRenderSystem(BaseSystem):
                 score_rect = score_text.get_rect()
                 score_rect.midleft = (padding + icon_size + 10, center_y)
             else:
-                score_rect = score_text.get_rect()
+            score_rect = score_text.get_rect()
                 score_rect.midleft = (padding, center_y)
 
             # blit score text

--- a/src/game/game_modes_registry.py
+++ b/src/game/game_modes_registry.py
@@ -30,6 +30,7 @@ SHRINKING_MODE_NAME = "Shrinking Mode"
 GAME_MODE_TELEPORT = "Teleport"
 BOX_MODE_NAME = "Box Mode"
 TRAIL_MODE_NAME = "Trail Mode"
+PLAYER_VS_PLAYER_MODE_NAME = "Player vs Player"
 
 ACTUAL_GAME_MODES = [
     {
@@ -77,6 +78,11 @@ ACTUAL_GAME_MODES = [
         "description": "Every tile the snake moves through becomes a permanent obstacle.",
         "detailed_info": "Leave your mark - permanently! Every tile you move through becomes a solid obstacle that remains for the rest of the game. The board fills up as you play, creating an ever-shrinking maze. Requires careful path planning to avoid trapping yourself. How long can you survive?",
     },
+    {
+        "name": PLAYER_VS_PLAYER_MODE_NAME,
+        "description": "Two players compete locally on the same board!",
+        "detailed_info": "Grab a friend and compete head-to-head! Player 1 uses WASD, Player 2 uses Arrow keys. Each player has 3 lives and respawns after 3 seconds. Colliding with your opponent costs a life. Last player standing wins!",
+    },
 ]
 
 RANDOM_MODE_LABEL = "Random"
@@ -90,6 +96,7 @@ __all__ = [
     "GAME_MODE_TELEPORT",
     "BOX_MODE_NAME",
     "TRAIL_MODE_NAME",
+    "PLAYER_VS_PLAYER_MODE_NAME",
     "ACTUAL_GAME_MODES",
     "RANDOM_MODE_LABEL",
     "RANDOM_MODE_INDEX",

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -93,6 +93,7 @@ class GameOverScene(BaseScene):
     def _is_pvp_mode(self) -> bool:
         """Check if the game was in PvP mode."""
         from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
+
         if self._world:
             game_states = self._world.registry.query_by_component("game_state")
             if game_states:
@@ -102,17 +103,18 @@ class GameOverScene(BaseScene):
 
     def _get_pvp_player_scores(self) -> list[tuple[int, int, int]]:
         """Get player scores and deaths from PvP mode.
-        
+
         Returns:
             List of (player_number, score, deaths) tuples
         """
         if not self._world:
             return []
-        
+
         from ecs.entities.entity import EntityType
+
         snakes = self._world.registry.query_by_type(EntityType.SNAKE)
         player_data = []
-        
+
         for snake_id, snake in snakes.items():
             if hasattr(snake, "player_id") and hasattr(snake, "lives"):
                 player_num = snake.player_id.player_number
@@ -120,7 +122,7 @@ class GameOverScene(BaseScene):
                 # Calculate deaths from initial lives (3) minus remaining lives
                 deaths = 3 - snake.lives.remaining
                 player_data.append((player_num, score, deaths))
-        
+
         # Sort by player number
         player_data.sort(key=lambda x: x[0])
         return player_data
@@ -128,12 +130,17 @@ class GameOverScene(BaseScene):
     @property
     def _is_draw(self) -> bool:
         """Check if this is a draw/tie."""
-        return "draw" in self._death_reason.lower() or "tied" in self._death_reason.lower()
-    
+        return (
+            "draw" in self._death_reason.lower() or "tied" in self._death_reason.lower()
+        )
+
     @property
     def _is_victory(self) -> bool:
         """Check if this is a victory (win) instead of a death (loss)."""
-        return self._death_reason.startswith("Win:") or "wins" in self._death_reason.lower()
+        return (
+            self._death_reason.startswith("Win:")
+            or "wins" in self._death_reason.lower()
+        )
 
     @property
     def _victory_message(self) -> str:
@@ -211,7 +218,7 @@ class GameOverScene(BaseScene):
 
             # Check if this is PvP mode
             is_pvp = self._is_pvp_mode()
-            
+
             # Use victory or game over colors based on win/loss/draw
             if self._is_draw:
                 # Draw/tie - use neutral/highlight colors
@@ -242,12 +249,12 @@ class GameOverScene(BaseScene):
                 title_surface = medium_font.render(title_text, True, title_color)
             else:
                 title_surface = big_font.render(title_text, True, title_color)
-            
+
             # Check if text is too wide and scale down if needed
             if title_surface.get_width() > self._width * 0.9:
                 # Text too wide, use medium font
                 title_surface = medium_font.render(title_text, True, title_color)
-            
+
             title_rect = title_surface.get_rect(
                 center=(self._width // 2, self._height / 5)
             )
@@ -255,16 +262,18 @@ class GameOverScene(BaseScene):
 
             # Display victory message or "NEW HIGH SCORE!" below title
             y_offset = self._height / 3.5
-            
+
             # In PvP mode, show player scores and deaths
             if is_pvp:
                 player_data = self._get_pvp_player_scores()
                 if player_data:
                     for player_num, score, deaths in player_data:
-                        player_color = (100, 255, 100) if player_num == 1 else (100, 150, 255)
+                        player_color = (
+                            (100, 255, 100) if player_num == 1 else (100, 150, 255)
+                        )
                         # Calculate final score (points - deaths)
                         final_score = score - deaths
-                        
+
                         # Display player info on two lines for better fit
                         # Line 1: Player name and points
                         player_text = small_font.render(
@@ -275,10 +284,12 @@ class GameOverScene(BaseScene):
                         )
                         self._renderer.blit(player_text, player_rect)
                         y_offset += 35
-                        
+
                         # Line 2: Deaths and final score
                         stats_text = small_font.render(
-                            f"Deaths: {deaths} | Final Score: {final_score}", True, player_color
+                            f"Deaths: {deaths} | Final Score: {final_score}",
+                            True,
+                            player_color,
                         )
                         stats_rect = stats_text.get_rect(
                             center=(self._width // 2, y_offset)

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -90,10 +90,43 @@ class GameOverScene(BaseScene):
         self._is_new_high_score = False
         self._new_score_timestamp = None
 
+    def _is_pvp_mode(self) -> bool:
+        """Check if the game was in PvP mode."""
+        from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
+        if self._world:
+            game_states = self._world.registry.query_by_component("game_state")
+            if game_states:
+                game_state = list(game_states.values())[0].game_state
+                return game_state.game_mode == PLAYER_VS_PLAYER_MODE_NAME
+        return False
+
+    def _get_pvp_player_scores(self) -> list[tuple[int, int]]:
+        """Get player scores from PvP mode.
+        
+        Returns:
+            List of (player_number, score) tuples
+        """
+        if not self._world:
+            return []
+        
+        from ecs.entities.entity import EntityType
+        snakes = self._world.registry.query_by_type(EntityType.SNAKE)
+        player_scores = []
+        
+        for snake_id, snake in snakes.items():
+            if hasattr(snake, "player_id"):
+                player_num = snake.player_id.player_number
+                score = snake.player_id.score
+                player_scores.append((player_num, score))
+        
+        # Sort by player number
+        player_scores.sort(key=lambda x: x[0])
+        return player_scores
+
     @property
     def _is_victory(self) -> bool:
         """Check if this is a victory (win) instead of a death (loss)."""
-        return self._death_reason.startswith("Win:")
+        return self._death_reason.startswith("Win:") or "wins" in self._death_reason.lower()
 
     @property
     def _victory_message(self) -> str:
@@ -165,6 +198,9 @@ class GameOverScene(BaseScene):
                 small_font = pygame.font.Font(None, small_font_size)
                 tiny_font = pygame.font.Font(None, tiny_font_size)
 
+            # Check if this is PvP mode
+            is_pvp = self._is_pvp_mode()
+            
             # Use victory or game over colors based on win/loss
             if self._is_victory:
                 title_color = VICTORY_TITLE_COLOR
@@ -172,7 +208,7 @@ class GameOverScene(BaseScene):
                 highlight_color = VICTORY_HIGHLIGHT_COLOR
                 high_score_color = VICTORY_HIGH_SCORE_COLOR
                 new_score_color = VICTORY_HIGHLIGHT_COLOR
-                title_text = "You Win!"
+                title_text = "You Win!" if not is_pvp else self._victory_message
             else:
                 title_color = GAME_OVER_MESSAGE_COLOR
                 message_color = GAME_OVER_MESSAGE_COLOR
@@ -190,33 +226,49 @@ class GameOverScene(BaseScene):
 
             # Display victory message or "NEW HIGH SCORE!" below title
             y_offset = self._height / 3.5
-            if self._is_victory:
-                # Show victory message (e.g., "Fully Shrunk!", "Board Complete!")
-                victory_text = medium_font.render(
-                    self._victory_message, True, message_color
-                )
-                victory_rect = victory_text.get_rect(
-                    center=(self._width // 2, y_offset)
-                )
-                self._renderer.blit(victory_text, victory_rect)
-                y_offset += 50
+            
+            # In PvP mode, show player scores
+            if is_pvp:
+                player_scores = self._get_pvp_player_scores()
+                if player_scores:
+                    for player_num, score in player_scores:
+                        player_color = (100, 255, 100) if player_num == 1 else (100, 150, 255)
+                        player_text = medium_font.render(
+                            f"Player {player_num}: {score} points", True, player_color
+                        )
+                        player_rect = player_text.get_rect(
+                            center=(self._width // 2, y_offset)
+                        )
+                        self._renderer.blit(player_text, player_rect)
+                        y_offset += 50
+            else:
+                if self._is_victory:
+                    # Show victory message (e.g., "Fully Shrunk!", "Board Complete!")
+                    victory_text = medium_font.render(
+                        self._victory_message, True, message_color
+                    )
+                    victory_rect = victory_text.get_rect(
+                        center=(self._width // 2, y_offset)
+                    )
+                    self._renderer.blit(victory_text, victory_rect)
+                    y_offset += 50
 
-            if self._is_new_high_score:
-                high_score_text = medium_font.render(
-                    "* NEW HIGH SCORE! *", True, high_score_color
-                )
-                high_score_rect = high_score_text.get_rect(
-                    center=(self._width // 2, y_offset)
-                )
-                self._renderer.blit(high_score_text, high_score_rect)
-                y_offset += 50
+                if self._is_new_high_score:
+                    high_score_text = medium_font.render(
+                        "* NEW HIGH SCORE! *", True, high_score_color
+                    )
+                    high_score_rect = high_score_text.get_rect(
+                        center=(self._width // 2, y_offset)
+                    )
+                    self._renderer.blit(high_score_text, high_score_rect)
+                    y_offset += 50
 
-            # Display current score
-            score_text = medium_font.render(
-                f"Your Score: {self._current_score}", True, highlight_color
-            )
-            score_rect = score_text.get_rect(center=(self._width // 2, y_offset))
-            self._renderer.blit(score_text, score_rect)
+                # Display current score
+                score_text = medium_font.render(
+                    f"Your Score: {self._current_score}", True, highlight_color
+                )
+                score_rect = score_text.get_rect(center=(self._width // 2, y_offset))
+                self._renderer.blit(score_text, score_rect)
 
             # Display top scores for current settings
             if self._scoreboard and self._settings:

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -100,28 +100,30 @@ class GameOverScene(BaseScene):
                 return game_state.game_mode == PLAYER_VS_PLAYER_MODE_NAME
         return False
 
-    def _get_pvp_player_scores(self) -> list[tuple[int, int]]:
-        """Get player scores from PvP mode.
+    def _get_pvp_player_scores(self) -> list[tuple[int, int, int]]:
+        """Get player scores and deaths from PvP mode.
         
         Returns:
-            List of (player_number, score) tuples
+            List of (player_number, score, deaths) tuples
         """
         if not self._world:
             return []
         
         from ecs.entities.entity import EntityType
         snakes = self._world.registry.query_by_type(EntityType.SNAKE)
-        player_scores = []
+        player_data = []
         
         for snake_id, snake in snakes.items():
-            if hasattr(snake, "player_id"):
+            if hasattr(snake, "player_id") and hasattr(snake, "lives"):
                 player_num = snake.player_id.player_number
                 score = snake.player_id.score
-                player_scores.append((player_num, score))
+                # Calculate deaths from initial lives (3) minus remaining lives
+                deaths = 3 - snake.lives.remaining
+                player_data.append((player_num, score, deaths))
         
         # Sort by player number
-        player_scores.sort(key=lambda x: x[0])
-        return player_scores
+        player_data.sort(key=lambda x: x[0])
+        return player_data
 
     @property
     def _is_victory(self) -> bool:
@@ -136,8 +138,12 @@ class GameOverScene(BaseScene):
         This allows new game modes to automatically use their custom message
         by setting death_reason to 'Win: <their message>'.
         """
-        if self._is_victory and len(self._death_reason) > 5:
-            return self._death_reason[5:].strip()  # Remove 'Win: ' prefix
+        if self._is_victory:
+            if self._death_reason.startswith("Win: "):
+                return self._death_reason[5:].strip()  # Remove 'Win: ' prefix
+            else:
+                # Return the whole message for PvP mode (e.g., "Player 2 wins!")
+                return self._death_reason
         return "You completed the game!"  # Default fallback for others
 
     def update(self, dt_ms: float) -> Optional[str]:
@@ -227,14 +233,16 @@ class GameOverScene(BaseScene):
             # Display victory message or "NEW HIGH SCORE!" below title
             y_offset = self._height / 3.5
             
-            # In PvP mode, show player scores
+            # In PvP mode, show player scores and deaths
             if is_pvp:
-                player_scores = self._get_pvp_player_scores()
-                if player_scores:
-                    for player_num, score in player_scores:
+                player_data = self._get_pvp_player_scores()
+                if player_data:
+                    for player_num, score, deaths in player_data:
                         player_color = (100, 255, 100) if player_num == 1 else (100, 150, 255)
+                        # Calculate final score (points - deaths)
+                        final_score = score - deaths
                         player_text = medium_font.render(
-                            f"Player {player_num}: {score} points", True, player_color
+                            f"Player {player_num}: {score} pts | {deaths} deaths | Score: {final_score}", True, player_color
                         )
                         player_rect = player_text.get_rect(
                             center=(self._width // 2, y_offset)

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -126,6 +126,11 @@ class GameOverScene(BaseScene):
         return player_data
 
     @property
+    def _is_draw(self) -> bool:
+        """Check if this is a draw/tie."""
+        return "draw" in self._death_reason.lower() or "tied" in self._death_reason.lower()
+    
+    @property
     def _is_victory(self) -> bool:
         """Check if this is a victory (win) instead of a death (loss)."""
         return self._death_reason.startswith("Win:") or "wins" in self._death_reason.lower()
@@ -207,8 +212,16 @@ class GameOverScene(BaseScene):
             # Check if this is PvP mode
             is_pvp = self._is_pvp_mode()
             
-            # Use victory or game over colors based on win/loss
-            if self._is_victory:
+            # Use victory or game over colors based on win/loss/draw
+            if self._is_draw:
+                # Draw/tie - use neutral/highlight colors
+                title_color = VICTORY_HIGHLIGHT_COLOR
+                message_color = GAME_OVER_MESSAGE_COLOR
+                highlight_color = GAME_OVER_HIGHLIGHT_COLOR
+                high_score_color = GAME_OVER_HIGH_SCORE_COLOR
+                new_score_color = GAME_OVER_NEW_SCORE_COLOR
+                title_text = "DRAW!!" if is_pvp else "Game Over"
+            elif self._is_victory:
                 title_color = VICTORY_TITLE_COLOR
                 message_color = VICTORY_MESSAGE_COLOR
                 highlight_color = VICTORY_HIGHLIGHT_COLOR
@@ -223,9 +236,9 @@ class GameOverScene(BaseScene):
                 new_score_color = GAME_OVER_NEW_SCORE_COLOR
                 title_text = "Game Over"
 
-            # Title text (either "You Win!" or "Game Over") centered
+            # Title text (either "You Win!", "DRAW!!" or "Game Over") centered
             # Use medium font for longer PvP victory messages to ensure they fit
-            if is_pvp and self._is_victory and len(title_text) > 10:
+            if is_pvp and (self._is_victory or self._is_draw) and len(title_text) > 10:
                 title_surface = medium_font.render(title_text, True, title_color)
             else:
                 title_surface = big_font.render(title_text, True, title_color)

--- a/src/game/scenes/game_over.py
+++ b/src/game/scenes/game_over.py
@@ -224,7 +224,17 @@ class GameOverScene(BaseScene):
                 title_text = "Game Over"
 
             # Title text (either "You Win!" or "Game Over") centered
-            title_surface = big_font.render(title_text, True, title_color)
+            # Use medium font for longer PvP victory messages to ensure they fit
+            if is_pvp and self._is_victory and len(title_text) > 10:
+                title_surface = medium_font.render(title_text, True, title_color)
+            else:
+                title_surface = big_font.render(title_text, True, title_color)
+            
+            # Check if text is too wide and scale down if needed
+            if title_surface.get_width() > self._width * 0.9:
+                # Text too wide, use medium font
+                title_surface = medium_font.render(title_text, True, title_color)
+            
             title_rect = title_surface.get_rect(
                 center=(self._width // 2, self._height / 5)
             )
@@ -241,14 +251,27 @@ class GameOverScene(BaseScene):
                         player_color = (100, 255, 100) if player_num == 1 else (100, 150, 255)
                         # Calculate final score (points - deaths)
                         final_score = score - deaths
-                        player_text = medium_font.render(
-                            f"Player {player_num}: {score} pts | {deaths} deaths | Score: {final_score}", True, player_color
+                        
+                        # Display player info on two lines for better fit
+                        # Line 1: Player name and points
+                        player_text = small_font.render(
+                            f"Player {player_num}: {score} points", True, player_color
                         )
                         player_rect = player_text.get_rect(
                             center=(self._width // 2, y_offset)
                         )
                         self._renderer.blit(player_text, player_rect)
-                        y_offset += 50
+                        y_offset += 35
+                        
+                        # Line 2: Deaths and final score
+                        stats_text = small_font.render(
+                            f"Deaths: {deaths} | Final Score: {final_score}", True, player_color
+                        )
+                        stats_rect = stats_text.get_rect(
+                            center=(self._width // 2, y_offset)
+                        )
+                        self._renderer.blit(stats_text, stats_rect)
+                        y_offset += 45
             else:
                 if self._is_victory:
                     # Show victory message (e.g., "Fully Shrunk!", "Board Complete!")
@@ -278,8 +301,8 @@ class GameOverScene(BaseScene):
                 score_rect = score_text.get_rect(center=(self._width // 2, y_offset))
                 self._renderer.blit(score_text, score_rect)
 
-            # Display top scores for current settings
-            if self._scoreboard and self._settings:
+            # Display top scores for current settings (not in PvP mode)
+            if self._scoreboard and self._settings and not is_pvp:
                 y_offset += 100  # Increased spacing before high scores section
 
                 # Use shorter text if width is too small

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -48,7 +48,11 @@ from ecs.systems.settings_apply import SettingsApplySystem
 from ecs.systems.trail_generation import TrailGenerationSystem
 from ecs.systems.trail_decay import TrailDecaySystem
 from game.scenes.game_modes import get_resolved_game_mode
-from game.game_modes_registry import CLASSIC_MODE_NAME, BOX_MODE_NAME, PLAYER_VS_PLAYER_MODE_NAME
+from game.game_modes_registry import (
+    CLASSIC_MODE_NAME,
+    BOX_MODE_NAME,
+    PLAYER_VS_PLAYER_MODE_NAME,
+)
 from ecs.systems.hunger import HungerSystem
 from ecs.systems.respawn import RespawnSystem
 from game.settings import GameSettings
@@ -135,7 +139,7 @@ class GameplayScene(BaseScene):
         if self._renderer:
             self._overlay_render_system = OverlayRenderSystem(
                 self._renderer, self._settings, self._config
-        )
+            )
 
         # game logic systems (indices 0-7, paused during pause)
         from ecs.systems.apple_spawn import AppleSpawnSystem
@@ -147,16 +151,16 @@ class GameplayScene(BaseScene):
 
         # build game logic systems list
         game_logic_systems = [
-                InputSystem(
+            InputSystem(
                 self._pygame_adapter,
                 self._settings,
                 self._current_game_mode,
                 self._overlay_render_system,
-                ),  # 0: read user input and update velocity/game state
+            ),  # 0: read user input and update velocity/game state
             autoplay_system,  # 1: calculate next move in autoplay mode (with victory handling)
-                MovementSystem(
-                    self._get_electric_walls
-                ),  # 2: update entity positions based on velocity
+            MovementSystem(
+                self._get_electric_walls
+            ),  # 2: update entity positions based on velocity
             TrailGenerationSystem(),  # 3: create trail obstacles in Trail Mode
             TrailDecaySystem(),  # 4: decay and remove old trail obstacles
         ]
@@ -170,7 +174,11 @@ class GameplayScene(BaseScene):
             )
 
         # create respawn system for PvP mode
-        respawn_system = RespawnSystem() if self._current_game_mode == PLAYER_VS_PLAYER_MODE_NAME else None
+        respawn_system = (
+            RespawnSystem()
+            if self._current_game_mode == PLAYER_VS_PLAYER_MODE_NAME
+            else None
+        )
 
         game_logic_systems.extend(
             [
@@ -191,9 +199,9 @@ class GameplayScene(BaseScene):
                     AppleSpawnSystem(
                         1000
                     ),  # 5: maintain correct number of apples on board
-                SpawnSystem(
-                    1000, (255, 0, 0), None
-                ),  # 6: create new entities at valid positions
+                    SpawnSystem(
+                        1000, (255, 0, 0), None
+                    ),  # 6: create new entities at valid positions
                 ]
             )
 
@@ -212,11 +220,7 @@ class GameplayScene(BaseScene):
                     else []
                 ),
                 # 7.5: add respawn system for PvP mode
-                *(
-                    [respawn_system]
-                    if respawn_system is not None
-                    else []
-                ),
+                *([respawn_system] if respawn_system is not None else []),
                 scoring_system,  # 8: track score and high score
                 ObstacleGenerationSystem(
                     100, 8, 2, None

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -135,7 +135,7 @@ class GameplayScene(BaseScene):
         if self._renderer:
             self._overlay_render_system = OverlayRenderSystem(
                 self._renderer, self._settings, self._config
-            )
+        )
 
         # game logic systems (indices 0-7, paused during pause)
         from ecs.systems.apple_spawn import AppleSpawnSystem
@@ -147,16 +147,16 @@ class GameplayScene(BaseScene):
 
         # build game logic systems list
         game_logic_systems = [
-            InputSystem(
+                InputSystem(
                 self._pygame_adapter,
                 self._settings,
                 self._current_game_mode,
                 self._overlay_render_system,
-            ),  # 0: read user input and update velocity/game state
+                ),  # 0: read user input and update velocity/game state
             autoplay_system,  # 1: calculate next move in autoplay mode (with victory handling)
-            MovementSystem(
-                self._get_electric_walls
-            ),  # 2: update entity positions based on velocity
+                MovementSystem(
+                    self._get_electric_walls
+                ),  # 2: update entity positions based on velocity
             TrailGenerationSystem(),  # 3: create trail obstacles in Trail Mode
             TrailDecaySystem(),  # 4: decay and remove old trail obstacles
         ]
@@ -191,9 +191,9 @@ class GameplayScene(BaseScene):
                     AppleSpawnSystem(
                         1000
                     ),  # 5: maintain correct number of apples on board
-                    SpawnSystem(
-                        1000, (255, 0, 0), None
-                    ),  # 6: create new entities at valid positions
+                SpawnSystem(
+                    1000, (255, 0, 0), None
+                ),  # 6: create new entities at valid positions
                 ]
             )
 

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -48,8 +48,9 @@ from ecs.systems.settings_apply import SettingsApplySystem
 from ecs.systems.trail_generation import TrailGenerationSystem
 from ecs.systems.trail_decay import TrailDecaySystem
 from game.scenes.game_modes import get_resolved_game_mode
-from game.game_modes_registry import CLASSIC_MODE_NAME, BOX_MODE_NAME
+from game.game_modes_registry import CLASSIC_MODE_NAME, BOX_MODE_NAME, PLAYER_VS_PLAYER_MODE_NAME
 from ecs.systems.hunger import HungerSystem
+from ecs.systems.respawn import RespawnSystem
 from game.settings import GameSettings
 from game.services.game_over_service import GameOverService
 
@@ -168,6 +169,9 @@ class GameplayScene(BaseScene):
                 ]
             )
 
+        # create respawn system for PvP mode
+        respawn_system = RespawnSystem() if self._current_game_mode == PLAYER_VS_PLAYER_MODE_NAME else None
+
         game_logic_systems.extend(
             [
                 CollisionSystem(
@@ -175,7 +179,8 @@ class GameplayScene(BaseScene):
                     self._audio_service,
                     scoring_system,
                     game_over_service,
-                ),  # 4: detect collisions (wall, self-bite, obstacles, apples, boxes)
+                    respawn_system,
+                ),  # 4: detect collisions (wall, self-bite, obstacles, apples, boxes, player-vs-player)
             ]
         )
 
@@ -204,6 +209,12 @@ class GameplayScene(BaseScene):
                 *(
                     [HungerSystem(game_over_service=game_over_service)]
                     if self._settings and bool(self._settings.get("enable_hunger"))
+                    else []
+                ),
+                # 7.5: add respawn system for PvP mode
+                *(
+                    [respawn_system]
+                    if respawn_system is not None
                     else []
                 ),
                 scoring_system,  # 8: track score and high score

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -94,27 +94,27 @@ class SettingsScene(BaseScene):
         """
         from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
         from game.scenes.game_modes import get_resolved_game_mode
-        
+
         # Check if we're in PvP mode
         current_mode = get_resolved_game_mode()
         is_pvp = current_mode == PLAYER_VS_PLAYER_MODE_NAME
-        
+
         visible = []
         for field in self._settings.MENU_FIELDS:
             # skip PvP-only fields if not in PvP mode
             if field.get("pvp_only", False) and not is_pvp:
                 continue
-            
+
             # create a copy of the field to avoid modifying the original
             field_copy = field.copy()
-            
+
             # adjust label for snake color based on mode
             if field_copy["key"] == "snake_color_palette":
                 if is_pvp:
                     field_copy["label"] = "Snake (WASD)"
                 else:
                     field_copy["label"] = "Snake color"
-                
+
             # section headers are always visible
             if field_copy["type"] == "section":
                 visible.append(field_copy)

--- a/src/game/scenes/settings.py
+++ b/src/game/scenes/settings.py
@@ -92,17 +92,38 @@ class SettingsScene(BaseScene):
         Returns:
             List of visible fields
         """
+        from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
+        from game.scenes.game_modes import get_resolved_game_mode
+        
+        # Check if we're in PvP mode
+        current_mode = get_resolved_game_mode()
+        is_pvp = current_mode == PLAYER_VS_PLAYER_MODE_NAME
+        
         visible = []
         for field in self._settings.MENU_FIELDS:
+            # skip PvP-only fields if not in PvP mode
+            if field.get("pvp_only", False) and not is_pvp:
+                continue
+            
+            # create a copy of the field to avoid modifying the original
+            field_copy = field.copy()
+            
+            # adjust label for snake color based on mode
+            if field_copy["key"] == "snake_color_palette":
+                if is_pvp:
+                    field_copy["label"] = "Snake (WASD)"
+                else:
+                    field_copy["label"] = "Snake color"
+                
             # section headers are always visible
-            if field["type"] == "section":
-                visible.append(field)
+            if field_copy["type"] == "section":
+                visible.append(field_copy)
             # regular fields are visible if they don't have a parent section,
             # or if their parent section is not collapsed
             else:
-                parent = field.get("parent_section")
+                parent = field_copy.get("parent_section")
                 if not parent or parent not in self._collapsed_sections:
-                    visible.append(field)
+                    visible.append(field_copy)
         return visible
 
     def _toggle_section(self, section_key: str) -> None:

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -36,6 +36,7 @@ from game.game_modes_registry import (
     AUTOPLAY_MODE_NAME,
     BOX_MODE_NAME,
     TRAIL_MODE_NAME,
+    PLAYER_VS_PLAYER_MODE_NAME,
 )
 
 
@@ -141,15 +142,23 @@ class GameInitializer:
         # create color scheme entity for rendering systems
         self._create_color_scheme(world)
 
-        # create snake at center of board
-        self._create_snake(world, grid_size)
+        # create snake(s) at center of board
+        if self._game_mode == PLAYER_VS_PLAYER_MODE_NAME:
+            # create 2 snakes for PvP mode
+            self._create_pvp_snakes(world, grid_size)
+        else:
+            # create single snake for other modes
+            self._create_snake(world, grid_size)
 
         # create apple config entity (skip for Box Mode)
         if self._game_mode != BOX_MODE_NAME:
             self._create_apple_config(world)
 
-            # create initial apples
-            self._create_initial_apples(world, grid_size)
+            # create initial apples (2 for PvP, normal count for others)
+            if self._game_mode == PLAYER_VS_PLAYER_MODE_NAME:
+                self._create_pvp_apples(world, grid_size)
+            else:
+                self._create_initial_apples(world, grid_size)
 
         # create obstacles based on difficulty
         self._create_obstacles(world, grid_size)
@@ -275,6 +284,106 @@ class GameInitializer:
             shrinking_mode=(self._game_mode == SHRINKING_MODE_NAME),
             autoplay_mode=(self._game_mode == AUTOPLAY_MODE_NAME),
         )
+
+    def _create_pvp_snakes(self, world: World, grid_size: int) -> None:
+        """Create two snakes for Player vs Player mode.
+
+        Args:
+            world: ECS world instance
+            grid_size: Size of grid cells in pixels
+        """
+        from ecs.prefabs.snake import create_snake
+        from ecs.components.lives import Lives
+        from ecs.components.respawn_timer import RespawnTimer
+        from ecs.components.player_id import PlayerID
+        from ecs.entities.entity import EntityType
+
+        # Player 1 (left side) - Green
+        player1_x = world.board.width // 4
+        player1_y = world.board.height // 2
+        player1_id = create_snake(
+            world=world,
+            grid_size=grid_size,
+            initial_speed=float(self._settings.get("initial_speed")),
+            head_color=(0, 200, 0),  # Green
+            tail_color=(0, 255, 0),  # Light green
+            enable_hunger=False,  # Disable hunger in PvP
+            cheese_mode=False,
+            shrinking_mode=False,
+            autoplay_mode=False,
+            initial_x=player1_x,
+            initial_y=player1_y,
+        )
+
+        # Add PvP components to Player 1
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for snake_id, snake in snakes.items():
+            if snake_id == player1_id:
+                snake.lives = Lives(remaining=3, max_lives=3)
+                snake.respawn_timer = RespawnTimer()
+                snake.player_id = PlayerID(player_number=1, score=0)
+                break
+
+        # Player 2 (right side) - Blue
+        player2_x = (world.board.width * 3) // 4
+        player2_y = world.board.height // 2
+        player2_id = create_snake(
+            world=world,
+            grid_size=grid_size,
+            initial_speed=float(self._settings.get("initial_speed")),
+            head_color=(0, 100, 255),  # Blue
+            tail_color=(100, 150, 255),  # Light blue
+            enable_hunger=False,  # Disable hunger in PvP
+            cheese_mode=False,
+            shrinking_mode=False,
+            autoplay_mode=False,
+            initial_x=player2_x,
+            initial_y=player2_y,
+        )
+
+        # Add PvP components to Player 2
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for snake_id, snake in snakes.items():
+            if snake_id == player2_id:
+                snake.lives = Lives(remaining=3, max_lives=3)
+                snake.respawn_timer = RespawnTimer()
+                snake.player_id = PlayerID(player_number=2, score=0)
+                break
+
+    def _create_pvp_apples(self, world: World, grid_size: int) -> None:
+        """Create 2 apples for Player vs Player mode.
+
+        Args:
+            world: ECS world instance
+            grid_size: Size of grid cells in pixels
+        """
+        from ecs.prefabs.apple import create_apple
+        from ecs.entities.entity import EntityType
+
+        # Get occupied positions (both snakes)
+        occupied_positions = set()
+        snakes = world.registry.query_by_type(EntityType.SNAKE)
+        for _, snake in snakes.items():
+            if hasattr(snake, "position"):
+                occupied_positions.add((snake.position.x, snake.position.y))
+                if hasattr(snake, "body"):
+                    for segment in snake.body.segments:
+                        occupied_positions.add((segment.x, segment.y))
+
+        # Spawn 2 apples
+        for _ in range(2):
+            attempts = 0
+            max_attempts = 1000
+            while attempts < max_attempts:
+                x = random.randint(0, world.board.width - 1)
+                y = random.randint(0, world.board.height - 1)
+
+                if (x, y) not in occupied_positions:
+                    create_apple(world, x=x, y=y, grid_size=grid_size, color=None)
+                    occupied_positions.add((x, y))
+                    break
+
+                attempts += 1
 
     def _create_apple_config(self, world: World) -> None:
         """Create AppleConfig entity to track desired apple count.

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -298,15 +298,23 @@ class GameInitializer:
         from ecs.components.player_id import PlayerID
         from ecs.entities.entity import EntityType
 
-        # Player 1 (left side) - Green
+        # Player 1 (left side) - use color from settings
+        from core.types.color_utils import hex_to_rgb
+        
         player1_x = world.board.width // 4
         player1_y = world.board.height // 2
+        
+        # Get player 1 colors from settings
+        p1_colors = self._settings.get_snake_colors()
+        p1_head_color = hex_to_rgb(p1_colors["head"])
+        p1_tail_color = hex_to_rgb(p1_colors["tail"])
+        
         player1_id = create_snake(
             world=world,
             grid_size=grid_size,
             initial_speed=float(self._settings.get("initial_speed")),
-            head_color=(0, 200, 0),  # Green
-            tail_color=(0, 255, 0),  # Light green
+            head_color=p1_head_color,
+            tail_color=p1_tail_color,
             enable_hunger=False,  # Disable hunger in PvP
             cheese_mode=False,
             shrinking_mode=False,
@@ -324,15 +332,21 @@ class GameInitializer:
                 snake.player_id = PlayerID(player_number=1, score=0)
                 break
 
-        # Player 2 (right side) - Blue
+        # Player 2 (right side) - use color from settings
         player2_x = (world.board.width * 3) // 4
         player2_y = world.board.height // 2
+        
+        # Get player 2 colors from settings
+        p2_colors = self._settings.get_player2_colors()
+        p2_head_color = hex_to_rgb(p2_colors["head"])
+        p2_tail_color = hex_to_rgb(p2_colors["tail"])
+        
         player2_id = create_snake(
             world=world,
             grid_size=grid_size,
             initial_speed=float(self._settings.get("initial_speed")),
-            head_color=(0, 100, 255),  # Blue
-            tail_color=(100, 150, 255),  # Light blue
+            head_color=p2_head_color,
+            tail_color=p2_tail_color,
             enable_hunger=False,  # Disable hunger in PvP
             cheese_mode=False,
             shrinking_mode=False,

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -148,17 +148,17 @@ class GameInitializer:
             self._create_pvp_snakes(world, grid_size)
         else:
             # create single snake for other modes
-        self._create_snake(world, grid_size)
+            self._create_snake(world, grid_size)
 
         # create apple config entity (skip for Box Mode)
         if self._game_mode != BOX_MODE_NAME:
-        self._create_apple_config(world)
+            self._create_apple_config(world)
 
             # create initial apples (2 for PvP, normal count for others)
             if self._game_mode == PLAYER_VS_PLAYER_MODE_NAME:
                 self._create_pvp_apples(world, grid_size)
             else:
-        self._create_initial_apples(world, grid_size)
+                self._create_initial_apples(world, grid_size)
 
         # create obstacles based on difficulty
         self._create_obstacles(world, grid_size)

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -148,17 +148,17 @@ class GameInitializer:
             self._create_pvp_snakes(world, grid_size)
         else:
             # create single snake for other modes
-            self._create_snake(world, grid_size)
+        self._create_snake(world, grid_size)
 
         # create apple config entity (skip for Box Mode)
         if self._game_mode != BOX_MODE_NAME:
-            self._create_apple_config(world)
+        self._create_apple_config(world)
 
             # create initial apples (2 for PvP, normal count for others)
             if self._game_mode == PLAYER_VS_PLAYER_MODE_NAME:
                 self._create_pvp_apples(world, grid_size)
             else:
-                self._create_initial_apples(world, grid_size)
+        self._create_initial_apples(world, grid_size)
 
         # create obstacles based on difficulty
         self._create_obstacles(world, grid_size)

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -300,15 +300,15 @@ class GameInitializer:
 
         # Player 1 (left side) - use color from settings
         from core.types.color_utils import hex_to_rgb
-        
+
         player1_x = world.board.width // 4
         player1_y = world.board.height // 2
-        
+
         # Get player 1 colors from settings
         p1_colors = self._settings.get_snake_colors()
         p1_head_color = hex_to_rgb(p1_colors["head"])
         p1_tail_color = hex_to_rgb(p1_colors["tail"])
-        
+
         player1_id = create_snake(
             world=world,
             grid_size=grid_size,
@@ -335,12 +335,12 @@ class GameInitializer:
         # Player 2 (right side) - use color from settings
         player2_x = (world.board.width * 3) // 4
         player2_y = world.board.height // 2
-        
+
         # Get player 2 colors from settings
         p2_colors = self._settings.get_player2_colors()
         p2_head_color = hex_to_rgb(p2_colors["head"])
         p2_tail_color = hex_to_rgb(p2_colors["tail"])
-        
+
         player2_id = create_snake(
             world=world,
             grid_size=grid_size,

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -508,13 +508,13 @@ class GameSettings:
         elif kind == "select":
             options = field["options"]
             current_value = self.settings[key]
-            
+
             # Handle invalid saved value (e.g., "Classic Blue" which doesn't exist)
             if current_value not in options:
                 # Reset to first valid option
                 self.settings[key] = options[0]
                 current_value = options[0]
-            
+
             current_index = options.index(current_value)
             new_index = (current_index + direction) % len(options)
             self.settings[key] = options[new_index]
@@ -681,10 +681,10 @@ class GameSettings:
         """
         from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
         from game.scenes.game_modes import get_resolved_game_mode
-        
+
         current_mode = get_resolved_game_mode()
         is_pvp = current_mode == PLAYER_VS_PLAYER_MODE_NAME
-        
+
         return [
             field
             for field in self.MENU_FIELDS

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -42,6 +42,7 @@ class GameSettings:
         "dynamic_spawn_obstacles": False,
         "electric_walls": True,
         "snake_color_palette": "Classic Green",  # Snake color customization
+        "player2_color_palette": "Ocean",  # Player 2 color (PvP mode only)
         "board_color_palette": "Classic Dark",  # Board color customization
         "speed_increase_rate": "10%",  # Speed increase per apple: 5% or 10%
         "enable_hunger": False,
@@ -173,6 +174,15 @@ class GameSettings:
             "options": [palette["name"] for palette in SNAKE_COLOR_PALETTES],
             "requires_reset": False,
             "category": "Display",
+        },
+        {
+            "key": "player2_color_palette",
+            "label": "Snake (Arrows)",
+            "type": "select",
+            "options": [palette["name"] for palette in SNAKE_COLOR_PALETTES],
+            "requires_reset": False,
+            "category": "Display",
+            "pvp_only": True,  # Only show in PvP mode
         },
         {
             "key": "board_color_palette",
@@ -497,7 +507,15 @@ class GameSettings:
 
         elif kind == "select":
             options = field["options"]
-            current_index = options.index(self.settings[key])
+            current_value = self.settings[key]
+            
+            # Handle invalid saved value (e.g., "Classic Blue" which doesn't exist)
+            if current_value not in options:
+                # Reset to first valid option
+                self.settings[key] = options[0]
+                current_value = options[0]
+            
+            current_index = options.index(current_value)
             new_index = (current_index + direction) % len(options)
             self.settings[key] = options[new_index]
             return
@@ -620,6 +638,17 @@ class GameSettings:
         palette_name = self.settings.get("snake_color_palette", "Classic Green")
         return get_snake_colors_by_name(palette_name)
 
+    def get_player2_colors(self):
+        """Get Player 2 snake colors based on selected palette.
+
+        Returns:
+            dict: Dictionary with 'head', 'tail', and 'name' keys
+        """
+        from .constants import get_snake_colors_by_name
+
+        palette_name = self.settings.get("player2_color_palette", "Classic Blue")
+        return get_snake_colors_by_name(palette_name)
+
     def get_board_colors(self):
         """Get current board colors based on selected palette.
 
@@ -645,14 +674,22 @@ class GameSettings:
         """Get menu fields that can be changed during gameplay.
 
         Returns only settings that don't require a game reset.
+        Filters out PvP-only settings if not in PvP mode.
 
         Returns:
             List of field definitions that can be adjusted mid-game
         """
+        from game.game_modes_registry import PLAYER_VS_PLAYER_MODE_NAME
+        from game.scenes.game_modes import get_resolved_game_mode
+        
+        current_mode = get_resolved_game_mode()
+        is_pvp = current_mode == PLAYER_VS_PLAYER_MODE_NAME
+        
         return [
             field
             for field in self.MENU_FIELDS
             if not field.get("requires_reset", False)
+            and (not field.get("pvp_only", False) or is_pvp)
         ]
 
     def scoreboard_settings(self) -> dict[str, Any]:


### PR DESCRIPTION
### Closes #493

## Description
Implements a local multiplayer mode where two players compete on the same keyboard in a last-snake-standing battle.

## Features Implemented

### Core Gameplay
- **Dual Controls**: Player 1 (WASD) vs Player 2 (Arrow keys)
- **Lives System**: Each player starts with 3 lives
- **Respawn Mechanism**: 3-second countdown timer after death
- **Smart Spawn**: Safe position finding to avoid spawn-killing
- **Score-Based Victory**: Winner determined by `points - deaths` calculation
- **Draw Detection**: Handles tied scores with proper "DRAW!!" screen

### Visual
- **In-Game HUD**: Shows lives, score, and respawn timer for each player
  - Player 1: Bottom-left
  - Player 2: Bottom-right
- **Game Over Screen**: 
  - Displays both players' points, deaths, and final scores
  - Shows "Player X WINS!!" or "DRAW!! Tied Score"
- **Settings**: 
  - Separate color customization for each player
  - Player 2 color setting only visible in PvP mode

## Screenshots
<img width="874" height="914" alt="Screenshot 2025-12-11 at 14 31 17" src="https://github.com/user-attachments/assets/07628ac7-6d29-4e7f-ab4d-7b4d35fb12a8" />

<img width="838" height="859" alt="Screenshot 2025-12-11 at 14 31 49" src="https://github.com/user-attachments/assets/b9506006-1ff3-4bc7-b8d8-5d9506daab36" />
