### PR TITLE
[FEAT] Lights Out Gamemode 

### DIFF
--- a/src/ecs/components/game_state.py
+++ b/src/ecs/components/game_state.py
@@ -51,7 +51,6 @@ class GameState:
     trail_mode_enabled: bool = False
     shrinking_mode_enabled: bool = False
     lights_out_enabled: bool = False
-    lights_out_active: bool = False
     game_started: bool = False  # Set to True after first input
     final_score: int = 0  # score at time of death
     trail_obstacles: List[Tuple[int, int]] = field(default_factory=list)

--- a/src/ecs/components/game_state.py
+++ b/src/ecs/components/game_state.py
@@ -50,6 +50,8 @@ class GameState:
     cheese_mode_enabled: bool = False
     trail_mode_enabled: bool = False
     shrinking_mode_enabled: bool = False
+    lights_out_enabled: bool = False
+    lights_out_active: bool = False
     game_started: bool = False  # Set to True after first input
     final_score: int = 0  # score at time of death
     trail_obstacles: List[Tuple[int, int]] = field(default_factory=list)

--- a/src/ecs/components/lights_out_state.py
+++ b/src/ecs/components/lights_out_state.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>

--- a/src/ecs/components/lights_out_state.py
+++ b/src/ecs/components/lights_out_state.py
@@ -17,7 +17,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Lights Out mode state component."""
+"""Lights Out mode state component.
+
+Minimal state used by renderer and systems. Lights Out is an always-on
+mode in this branch; only `radius` is required by runtime logic.
+"""
 
 from dataclasses import dataclass
 
@@ -26,13 +30,9 @@ from dataclasses import dataclass
 class LightsOutState:
     """State for Lights Out game mode.
 
-    Tracks blackout timing and configuration for the periodic darkness effect.
-    Used by: Game entity (singleton)
-    Read by: LightsOutSystem, OverlayRenderSystem
-    Written by: LightsOutSystem
+    Only `radius` is kept because timing and duration-based fields are
+    removed in favor of an always-on implementation driven by systems
+    and rendering logic.
     """
 
-    interval: float = 12.0  # seconds between blackouts (cooldown duration)
-    duration: float = 4.0  # seconds of darkness per blackout
     radius: int = 4  # grid cells of visible radius around snake head
-    timer: float = 0.0  # time remaining in current state (active or cooldown)

--- a/src/ecs/components/lights_out_state.py
+++ b/src/ecs/components/lights_out_state.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
@@ -20,7 +21,7 @@
 """Lights Out mode state component.
 
 Minimal state used by renderer and systems. Lights Out is an always-on
-mode in this branch; only `radius` is required by runtime logic.
+mode, only `radius` is required by runtime logic.
 """
 
 from dataclasses import dataclass

--- a/src/ecs/components/lights_out_state.py
+++ b/src/ecs/components/lights_out_state.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Lights Out mode state component."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class LightsOutState:
+    """State for Lights Out game mode.
+
+    Tracks blackout timing and configuration for the periodic darkness effect.
+    Used by: Game entity (singleton)
+    Read by: LightsOutSystem, OverlayRenderSystem
+    Written by: LightsOutSystem
+    """
+
+    interval: float = 12.0  # seconds between blackouts (cooldown duration)
+    duration: float = 4.0  # seconds of darkness per blackout
+    radius: int = 4  # grid cells of visible radius around snake head
+    timer: float = 0.0  # time remaining in current state (active or cooldown)

--- a/src/ecs/systems/lights_out.py
+++ b/src/ecs/systems/lights_out.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
@@ -64,7 +63,7 @@ class LightsOutSystem(BaseSystem):
             return
 
         # Desired fixed radius in tiles
-        desired_radius = 4
+        desired_radius = 3
 
         # Defensive clamp against board size
         board_width = getattr(getattr(world, "board", None), "width", 1)
@@ -78,4 +77,3 @@ class LightsOutSystem(BaseSystem):
             radius = max_radius
 
         lights_out_state.radius = radius
-

--- a/src/ecs/systems/lights_out.py
+++ b/src/ecs/systems/lights_out.py
@@ -63,7 +63,7 @@ class LightsOutSystem(BaseSystem):
             return
 
         # Desired fixed radius in tiles
-        desired_radius = 3
+        desired_radius = 2.25
 
         # Defensive clamp against board size
         board_width = getattr(getattr(world, "board", None), "width", 1)

--- a/src/ecs/systems/lights_out.py
+++ b/src/ecs/systems/lights_out.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
@@ -16,20 +17,20 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Lights Out timing system.
 
-Keeps a simple on/off timer for the Lights Out game mode, toggling blackout
-state and updating remaining time so UI/render systems can read it.
+"""Lights Out system (Google-style always-on variant).
+
+This system is intentionally minimal: when the Lights Out mode is enabled it
+keeps `game_state.lights_out_active` set and enforces a constant vision radius
+around snake heads. There are no timers or temporary boosts here — the
+visual behaviour is driven by the renderer using `lights_out_state.radius`.
 """
 
 from ecs.systems.base_system import BaseSystem
 
 
 class LightsOutSystem(BaseSystem):
-    """Toggle blackout on a fixed interval/duration.
-
-    Uses GameState for enabled/active flags and LightsOutState for timing config.
-    """
+    """Always-on Lights Out: constant vision radius around snake head."""
 
     def __init__(self, settings=None):
         self._settings = settings
@@ -48,84 +49,39 @@ class LightsOutSystem(BaseSystem):
         entity = next(iter(entities.values()))
         return getattr(entity, "lights_out_state", None)
 
-    def _refresh_from_settings(self, state) -> None:
-        if not self._settings:
-            return
-        try:
-            interval_val = self._settings.get("lights_out_interval")
-            duration_val = self._settings.get("lights_out_duration")
-            radius_val = self._settings.get("lights_out_radius")
-
-            if interval_val is not None:
-                state.interval = float(interval_val)
-            if duration_val is not None:
-                state.duration = float(duration_val)
-            if radius_val is not None:
-                state.radius = int(radius_val)
-        except Exception:
-            # ignore malformed values; keep current ones
-            pass
-
     def update(self, world) -> None:
+        """Enforce always-on blackout and constant vision radius.
+
+        The radius is set to 4 tiles by design. Defensive clamping prevents
+        unrealistic values that could break rendering.
+        """
         game_state = self._get_game_state(world)
         lights_out_state = self._get_lights_out_state(world)
 
         if not game_state or not lights_out_state:
             return
 
-        self._refresh_from_settings(lights_out_state)
-
+        # Mode off -> ensure inactive
         if not game_state.lights_out_enabled:
-            # Ensure stable state when mode is inactive
             game_state.lights_out_active = False
             return
 
-        dt_seconds = 0.0
-        try:
-            dt_seconds = float(world.dt_ms) / 1000.0
-        except Exception:
-            dt_seconds = 0.016
+        # Mode enabled -> always active
+        game_state.lights_out_active = True
 
-        # Choose the target countdown based on current state
-        if game_state.lights_out_active:
-            lights_out_state.timer -= dt_seconds
-            if lights_out_state.timer <= 0:
-                game_state.lights_out_active = False
-                # start cooldown until next blackout
-                lights_out_state.timer = max(lights_out_state.interval, 0.1)
-        else:
-            # cooldown running
-            lights_out_state.timer -= dt_seconds
-            if lights_out_state.timer <= 0:
-                game_state.lights_out_active = True
-                # start blackout duration
-                lights_out_state.timer = max(lights_out_state.duration, 0.1)
+        # Desired fixed radius in tiles
+        desired_radius = 4
 
-        # Minimal runtime sanitization to ensure safe operation
-        # enforce positive interval and duration
-        if (
-            not isinstance(lights_out_state.interval, (int, float))
-            or lights_out_state.interval <= 0
-        ):
-            lights_out_state.interval = 12.0
-        if (
-            not isinstance(lights_out_state.duration, (int, float))
-            or lights_out_state.duration <= 0
-        ):
-            lights_out_state.duration = 4.0
-        # clamp radius to board bounds
-        max_radius = max(1, min(world.board.width, world.board.height))
-        if not isinstance(lights_out_state.radius, int):
-            try:
-                lights_out_state.radius = int(lights_out_state.radius)
-            except Exception:
-                lights_out_state.radius = 4
-        if lights_out_state.radius < 1:
-            lights_out_state.radius = 1
-        if lights_out_state.radius > max_radius:
-            lights_out_state.radius = max_radius
-        # ensure timer is valid and non-negative
-        if not isinstance(lights_out_state.timer, (int, float)):
-            lights_out_state.timer = lights_out_state.interval
-        if lights_out_state.timer < 0:
-            lights_out_state.timer = 0.0
+        # Defensive clamp against board size
+        board_width = getattr(getattr(world, "board", None), "width", 1)
+        board_height = getattr(getattr(world, "board", None), "height", 1)
+        max_radius = max(1, min(board_width, board_height))
+
+        radius = int(desired_radius)
+        if radius < 1:
+            radius = 1
+        if radius > max_radius:
+            radius = max_radius
+
+        lights_out_state.radius = radius
+

--- a/src/ecs/systems/lights_out.py
+++ b/src/ecs/systems/lights_out.py
@@ -21,9 +21,9 @@
 """Lights Out system (Google-style always-on variant).
 
 This system is intentionally minimal: when the Lights Out mode is enabled it
-keeps `game_state.lights_out_active` set and enforces a constant vision radius
-around snake heads. There are no timers or temporary boosts here — the
-visual behaviour is driven by the renderer using `lights_out_state.radius`.
+enforces a constant vision radius around snake heads. There are no timers or
+temporary boosts here — the visual behaviour is driven by the renderer using
+`lights_out_state.radius`.
 """
 
 from ecs.systems.base_system import BaseSystem
@@ -61,13 +61,9 @@ class LightsOutSystem(BaseSystem):
         if not game_state or not lights_out_state:
             return
 
-        # Mode off -> ensure inactive
+        # If the mode is not enabled, do nothing
         if not game_state.lights_out_enabled:
-            game_state.lights_out_active = False
             return
-
-        # Mode enabled -> always active
-        game_state.lights_out_active = True
 
         # Desired fixed radius in tiles
         desired_radius = 4

--- a/src/ecs/systems/lights_out.py
+++ b/src/ecs/systems/lights_out.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+#
+#   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
+#
+#   This file is part of Naja.
+#
+#   Naja is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Lights Out timing system.
+
+Keeps a simple on/off timer for the Lights Out game mode, toggling blackout
+state and updating remaining time so UI/render systems can read it.
+"""
+
+from ecs.systems.base_system import BaseSystem
+
+
+class LightsOutSystem(BaseSystem):
+    """Toggle blackout on a fixed interval/duration.
+
+    Uses GameState for enabled/active flags and LightsOutState for timing config.
+    """
+
+    def __init__(self, settings=None):
+        self._settings = settings
+
+    def _get_game_state(self, world):
+        entities = world.registry.query_by_component("game_state")
+        if not entities:
+            return None
+        entity = next(iter(entities.values()))
+        return getattr(entity, "game_state", None)
+
+    def _get_lights_out_state(self, world):
+        entities = world.registry.query_by_component("lights_out_state")
+        if not entities:
+            return None
+        entity = next(iter(entities.values()))
+        return getattr(entity, "lights_out_state", None)
+
+    def _refresh_from_settings(self, state) -> None:
+        if not self._settings:
+            return
+        try:
+            interval_val = self._settings.get("lights_out_interval")
+            duration_val = self._settings.get("lights_out_duration")
+            radius_val = self._settings.get("lights_out_radius")
+
+            if interval_val is not None:
+                state.interval = float(interval_val)
+            if duration_val is not None:
+                state.duration = float(duration_val)
+            if radius_val is not None:
+                state.radius = int(radius_val)
+        except Exception:
+            # ignore malformed values; keep current ones
+            pass
+
+    def update(self, world) -> None:
+        game_state = self._get_game_state(world)
+        lights_out_state = self._get_lights_out_state(world)
+
+        if not game_state or not lights_out_state:
+            return
+
+        self._refresh_from_settings(lights_out_state)
+
+        if not game_state.lights_out_enabled:
+            # Ensure stable state when mode is inactive
+            game_state.lights_out_active = False
+            return
+
+        dt_seconds = 0.0
+        try:
+            dt_seconds = float(world.dt_ms) / 1000.0
+        except Exception:
+            dt_seconds = 0.016
+
+        # Choose the target countdown based on current state
+        if game_state.lights_out_active:
+            lights_out_state.timer -= dt_seconds
+            if lights_out_state.timer <= 0:
+                game_state.lights_out_active = False
+                # start cooldown until next blackout
+                lights_out_state.timer = max(lights_out_state.interval, 0.1)
+        else:
+            # cooldown running
+            lights_out_state.timer -= dt_seconds
+            if lights_out_state.timer <= 0:
+                game_state.lights_out_active = True
+                # start blackout duration
+                lights_out_state.timer = max(lights_out_state.duration, 0.1)
+
+        # Clamp timer to avoid runaway negatives
+        if lights_out_state.timer < 0:
+            lights_out_state.timer = 0.0

--- a/src/ecs/systems/lights_out.py
+++ b/src/ecs/systems/lights_out.py
@@ -101,6 +101,31 @@ class LightsOutSystem(BaseSystem):
                 # start blackout duration
                 lights_out_state.timer = max(lights_out_state.duration, 0.1)
 
-        # Clamp timer to avoid runaway negatives
+        # Minimal runtime sanitization to ensure safe operation
+        # enforce positive interval and duration
+        if (
+            not isinstance(lights_out_state.interval, (int, float))
+            or lights_out_state.interval <= 0
+        ):
+            lights_out_state.interval = 12.0
+        if (
+            not isinstance(lights_out_state.duration, (int, float))
+            or lights_out_state.duration <= 0
+        ):
+            lights_out_state.duration = 4.0
+        # clamp radius to board bounds
+        max_radius = max(1, min(world.board.width, world.board.height))
+        if not isinstance(lights_out_state.radius, int):
+            try:
+                lights_out_state.radius = int(lights_out_state.radius)
+            except Exception:
+                lights_out_state.radius = 4
+        if lights_out_state.radius < 1:
+            lights_out_state.radius = 1
+        if lights_out_state.radius > max_radius:
+            lights_out_state.radius = max_radius
+        # ensure timer is valid and non-negative
+        if not isinstance(lights_out_state.timer, (int, float)):
+            lights_out_state.timer = lights_out_state.interval
         if lights_out_state.timer < 0:
             lights_out_state.timer = 0.0

--- a/src/ecs/systems/lights_out.py
+++ b/src/ecs/systems/lights_out.py
@@ -18,12 +18,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Lights Out system (Google-style always-on variant).
+"""Lights Out system
 
 This system is intentionally minimal: when the Lights Out mode is enabled it
-enforces a constant vision radius around snake heads. There are no timers or
-temporary boosts here — the visual behaviour is driven by the renderer using
-`lights_out_state.radius`.
+enforces a constant vision radius around snake heads. The visual behaviour is
+driven by the renderer using `lights_out_state.radius`.
 """
 
 from ecs.systems.base_system import BaseSystem
@@ -51,7 +50,6 @@ class LightsOutSystem(BaseSystem):
 
     def update(self, world) -> None:
         """Enforce always-on blackout and constant vision radius.
-
         The radius is set to 4 tiles by design. Defensive clamping prevents
         unrealistic values that could break rendering.
         """

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -213,10 +213,6 @@ class OverlayRenderSystem(BaseSystem):
                 return
 
             surface_width, surface_height = surface.get_size()
-
-            if not game_state.lights_out_active:
-                return
-
             # Create overlay only for the board area so the top UI/scoreboard
             # remains visible and is not blacked out.
             cell_size = getattr(world.board, "cell_size", 16)

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -190,8 +190,6 @@ class OverlayRenderSystem(BaseSystem):
             int(draw_y + offset_y + cell_size / 2),
         )
 
-    # Timer-based UI removed: Lights Out is always-on in this build.
-
     def draw_lights_out_overlay(self, world: World) -> None:
         """Render blackout mask for Lights Out mode (always-on).
 

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -26,6 +26,7 @@ overlay rendering (pause screen, settings menu) on top of the game.
 import pygame
 from ecs.systems.base_system import BaseSystem
 from ecs.world import World
+from ecs.entities.entity import EntityType
 from core.rendering.pygame_surface_renderer import RenderEnqueue
 from core.types.color import Color
 from game import constants
@@ -91,6 +92,172 @@ class OverlayRenderSystem(BaseSystem):
             self._collapsed_sections.remove(section_key)
         else:
             self._collapsed_sections.add(section_key)
+
+    def _get_lights_out_state(self, world: World):
+        entities = world.registry.query_by_component("lights_out_state")
+        if not entities:
+            return None
+        entity = next(iter(entities.values()))
+        return getattr(entity, "lights_out_state", None)
+
+    def _get_game_state(self, world: World):
+        entities = world.registry.query_by_component("game_state")
+        if not entities:
+            return None
+        entity = next(iter(entities.values()))
+        return getattr(entity, "game_state", None)
+
+    def _get_board_offset(self) -> tuple[int, int]:
+        """Match the board offset used by render systems."""
+        surface = pygame.display.get_surface()
+        if not surface:
+            return (0, 0)
+        return (0, 45)
+
+    def _calculate_interpolated_position(
+        self,
+        current_x: float,
+        current_y: float,
+        prev_x: float,
+        prev_y: float,
+        alpha: float,
+        wrapped_axis: str,
+        cell_size: int,
+        grid_width: int,
+        grid_height: int,
+    ) -> tuple[float, float]:
+        """Interpolate between previous and current positions handling wraparound."""
+        # Adjust for wraparound so interpolation follows the shorter path
+        if wrapped_axis in ("x", "both"):
+            if current_x < prev_x:
+                current_x += grid_width
+            else:
+                prev_x += grid_width
+
+        if wrapped_axis in ("y", "both"):
+            if current_y < prev_y:
+                current_y += grid_height
+            else:
+                prev_y += grid_height
+
+        interp_x = prev_x + (current_x - prev_x) * alpha
+        interp_y = prev_y + (current_y - prev_y) * alpha
+
+        # Wrap back into the grid range
+        interp_x %= grid_width
+        interp_y %= grid_height
+
+        return interp_x, interp_y
+
+    def _get_snake_head_screen_position(self, world: World):
+        snakes = world.registry.query_by_type_and_components(
+            EntityType.SNAKE, "position", "interpolation"
+        )
+        if not snakes:
+            snakes = world.registry.query_by_component("position", "interpolation")
+        if not snakes:
+            return None
+
+        snake = next(iter(snakes.values()))
+        position = getattr(snake, "position", None)
+        interpolation = getattr(snake, "interpolation", None)
+        if not position:
+            return None
+
+        cell_size = getattr(world.board, "cell_size", 20)
+        grid_width = getattr(world.board, "width", 0) * cell_size
+        grid_height = getattr(world.board, "height", 0) * cell_size
+
+        draw_x = position.x * cell_size
+        draw_y = position.y * cell_size
+
+        if interpolation:
+            draw_x, draw_y = self._calculate_interpolated_position(
+                position.x * cell_size,
+                position.y * cell_size,
+                position.prev_x * cell_size,
+                position.prev_y * cell_size,
+                interpolation.alpha,
+                interpolation.wrapped_axis,
+                cell_size,
+                grid_width,
+                grid_height,
+            )
+
+        offset_x, offset_y = self._get_board_offset()
+        return (
+            int(draw_x + offset_x + cell_size / 2),
+            int(draw_y + offset_y + cell_size / 2),
+        )
+
+    def _draw_lights_out_timer(
+        self, surface_width: int, surface_height: int, remaining: float, is_active: bool
+    ) -> None:
+        """Draw the countdown text for Lights Out mode."""
+        font_path = "assets/font/GetVoIP-Grotesque.ttf"
+        font_size = int(surface_width / 55)
+        try:
+            font = pygame.font.Font(font_path, font_size)
+        except Exception:
+            font = pygame.font.Font(None, font_size)
+
+        label_prefix = "Lights return in" if is_active else "Blackout in"
+        text_color = (255, 255, 255)
+        timer_text = font.render(f"{label_prefix} {remaining:.1f}s", True, text_color)
+        timer_rect = timer_text.get_rect()
+        padding = int(surface_width * 0.02)
+        timer_rect.topright = (
+            surface_width - padding,
+            padding + int(surface_height * 0.03),
+        )
+        self._renderer.blit(timer_text, timer_rect)
+
+    def draw_lights_out_overlay(self, world: World) -> None:
+        """Render blackout mask and timer for Lights Out mode."""
+        try:
+            game_state = self._get_game_state(world)
+            lights_out_state = self._get_lights_out_state(world)
+
+            if (
+                not game_state
+                or not lights_out_state
+                or not game_state.lights_out_enabled
+            ):
+                return
+
+            surface = pygame.display.get_surface()
+            if not surface:
+                return
+
+            surface_width, surface_height = surface.get_size()
+            remaining = max(0.0, float(lights_out_state.timer))
+
+            # Always draw the timer when mode is enabled
+            self._draw_lights_out_timer(
+                surface_width, surface_height, remaining, game_state.lights_out_active
+            )
+
+            if not game_state.lights_out_active:
+                return
+
+            overlay = pygame.Surface((surface_width, surface_height), pygame.SRCALPHA)
+            overlay.fill((0, 0, 0, 240))
+
+            center = self._get_snake_head_screen_position(world)
+            radius_px = max(
+                8,
+                int(lights_out_state.radius * getattr(world.board, "cell_size", 16)),
+            )
+
+            if center:
+                # carve a hole around the snake head
+                pygame.draw.circle(overlay, (0, 0, 0, 0), center, radius_px)
+
+            self._renderer.blit(overlay, (0, 0))
+
+        except Exception:
+            # Avoid breaking rendering if anything goes wrong
+            pass
 
     def draw_pause_overlay(self, surface_width: int, surface_height: int) -> None:
         """Draw pause overlay with semi-transparent background and text.
@@ -396,11 +563,10 @@ class OverlayRenderSystem(BaseSystem):
     def update(self, world: World) -> None:
         """Update method required by BaseSystem.
 
-        Renders overlays based on game state.
-        Note: This system is called manually from GameplayScene,
-        not in the regular system update loop.
+        Renders the Lights Out overlay based on game state. Pause/settings
+        overlays are still drawn explicitly by GameplayScene.
 
         Args:
             world: Game world
         """
-        pass  # overlays are drawn manually by GameplayScene
+        self.draw_lights_out_overlay(world)

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -190,30 +190,13 @@ class OverlayRenderSystem(BaseSystem):
             int(draw_y + offset_y + cell_size / 2),
         )
 
-    def _draw_lights_out_timer(
-        self, surface_width: int, surface_height: int, remaining: float, is_active: bool
-    ) -> None:
-        """Draw the countdown text for Lights Out mode."""
-        font_path = "assets/font/GetVoIP-Grotesque.ttf"
-        font_size = int(surface_width / 55)
-        try:
-            font = pygame.font.Font(font_path, font_size)
-        except Exception:
-            font = pygame.font.Font(None, font_size)
-
-        label_prefix = "Lights return in" if is_active else "Blackout in"
-        text_color = (255, 255, 255)
-        timer_text = font.render(f"{label_prefix} {remaining:.1f}s", True, text_color)
-        timer_rect = timer_text.get_rect()
-        padding = int(surface_width * 0.02)
-        timer_rect.topright = (
-            surface_width - padding,
-            padding + int(surface_height * 0.03),
-        )
-        self._renderer.blit(timer_text, timer_rect)
+    # Timer-based UI removed: Lights Out is always-on in this build.
 
     def draw_lights_out_overlay(self, world: World) -> None:
-        """Render blackout mask and timer for Lights Out mode."""
+        """Render blackout mask for Lights Out mode (always-on).
+
+        The mode is always-on in this build; no countdown/timers are displayed.
+        """
         try:
             game_state = self._get_game_state(world)
             lights_out_state = self._get_lights_out_state(world)
@@ -230,18 +213,13 @@ class OverlayRenderSystem(BaseSystem):
                 return
 
             surface_width, surface_height = surface.get_size()
-            remaining = max(0.0, float(lights_out_state.timer))
-
-            # Always draw the timer when mode is enabled
-            self._draw_lights_out_timer(
-                surface_width, surface_height, remaining, game_state.lights_out_active
-            )
 
             if not game_state.lights_out_active:
                 return
 
             overlay = pygame.Surface((surface_width, surface_height), pygame.SRCALPHA)
-            overlay.fill((0, 0, 0, 252))
+            # Pure black outside illuminated areas (user requested fully black)
+            overlay.fill((0, 0, 0, 255))
 
             center = self._get_snake_head_screen_position(world)
             radius_px = max(
@@ -252,6 +230,30 @@ class OverlayRenderSystem(BaseSystem):
             if center:
                 # carve a hole around the snake head
                 pygame.draw.circle(overlay, (0, 0, 0, 0), center, radius_px)
+
+            # Reveal apples only when their glow overlaps the snake's vision.
+            try:
+                from ecs.entities.entity import EntityType
+
+                cell_size = getattr(world.board, "cell_size", 16)
+                # Apple glow radius: 2 cells
+                apple_radius_px = max(4, int(2 * cell_size))
+                apples = world.registry.query_by_type(EntityType.APPLE)
+                offset_x, offset_y = self._get_board_offset()
+                for _, apple in apples.items():
+                    pos = getattr(apple, "position", None)
+                    if not pos:
+                        continue
+                    ax = int(pos.x * cell_size + offset_x + cell_size / 2)
+                    ay = int(pos.y * cell_size + offset_y + cell_size / 2)
+                    # Only carve apple hole if apple glow intersects snake vision
+                    if center:
+                        dx = ax - center[0]
+                        dy = ay - center[1]
+                        if dx * dx + dy * dy <= (radius_px + apple_radius_px) ** 2:
+                            pygame.draw.circle(overlay, (0, 0, 0, 0), (ax, ay), apple_radius_px)
+            except Exception:
+                pass
 
             self._renderer.blit(overlay, (0, 0))
 

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -38,6 +38,7 @@ class OverlayRenderSystem(BaseSystem):
     Responsibilities:
     - Render pause overlay (when paused)
     - Render settings overlay (when settings menu is open)
+    - Render Lights Out mode darkness overlay with vision circles
 
     NOT responsible for:
     - Basic HUD rendering (use UIRenderSystem)
@@ -114,82 +115,6 @@ class OverlayRenderSystem(BaseSystem):
             return (0, 0)
         return (0, 45)
 
-    def _calculate_interpolated_position(
-        self,
-        current_x: float,
-        current_y: float,
-        prev_x: float,
-        prev_y: float,
-        alpha: float,
-        wrapped_axis: str,
-        cell_size: int,
-        grid_width: int,
-        grid_height: int,
-    ) -> tuple[float, float]:
-        """Interpolate between previous and current positions handling wraparound."""
-        # Adjust for wraparound so interpolation follows the shorter path
-        if wrapped_axis in ("x", "both"):
-            if current_x < prev_x:
-                current_x += grid_width
-            else:
-                prev_x += grid_width
-
-        if wrapped_axis in ("y", "both"):
-            if current_y < prev_y:
-                current_y += grid_height
-            else:
-                prev_y += grid_height
-
-        interp_x = prev_x + (current_x - prev_x) * alpha
-        interp_y = prev_y + (current_y - prev_y) * alpha
-
-        # Wrap back into the grid range
-        interp_x %= grid_width
-        interp_y %= grid_height
-
-        return interp_x, interp_y
-
-    def _get_snake_head_screen_position(self, world: World):
-        snakes = world.registry.query_by_type_and_components(
-            EntityType.SNAKE, "position", "interpolation"
-        )
-        if not snakes:
-            snakes = world.registry.query_by_component("position", "interpolation")
-        if not snakes:
-            return None
-
-        snake = next(iter(snakes.values()))
-        position = getattr(snake, "position", None)
-        interpolation = getattr(snake, "interpolation", None)
-        if not position:
-            return None
-
-        cell_size = getattr(world.board, "cell_size", 20)
-        grid_width = getattr(world.board, "width", 0) * cell_size
-        grid_height = getattr(world.board, "height", 0) * cell_size
-
-        draw_x = position.x * cell_size
-        draw_y = position.y * cell_size
-
-        if interpolation:
-            draw_x, draw_y = self._calculate_interpolated_position(
-                position.x * cell_size,
-                position.y * cell_size,
-                position.prev_x * cell_size,
-                position.prev_y * cell_size,
-                interpolation.alpha,
-                interpolation.wrapped_axis,
-                cell_size,
-                grid_width,
-                grid_height,
-            )
-
-        offset_x, offset_y = self._get_board_offset()
-        return (
-            int(draw_x + offset_x + cell_size / 2),
-            int(draw_y + offset_y + cell_size / 2),
-        )
-
     def draw_lights_out_overlay(self, world: World) -> None:
         """Render blackout mask for Lights Out mode (always-on).
 
@@ -211,8 +136,6 @@ class OverlayRenderSystem(BaseSystem):
                 return
 
             surface_width, surface_height = surface.get_size()
-            # Create overlay only for the board area so the top UI/scoreboard
-            # remains visible and is not blacked out.
             cell_size = getattr(world.board, "cell_size", 16)
             board_px_w = getattr(world.board, "width", 0) * cell_size
             board_px_h = getattr(world.board, "height", 0) * cell_size
@@ -220,55 +143,202 @@ class OverlayRenderSystem(BaseSystem):
 
             # If board has zero size, fall back to full-surface overlay
             if board_px_w <= 0 or board_px_h <= 0:
-                overlay = pygame.Surface((surface_width, surface_height), pygame.SRCALPHA)
+                overlay = pygame.Surface(
+                    (surface_width, surface_height), pygame.SRCALPHA
+                )
                 overlay.fill((0, 0, 0, 255))
-                overlay_blit_pos = (0, 0)
-            else:
-                overlay = pygame.Surface((board_px_w, board_px_h), pygame.SRCALPHA)
-                overlay.fill((0, 0, 0, 255))
-                overlay_blit_pos = (offset_x, offset_y)
+                self._renderer.blit(overlay, (0, 0))
+                return
+            # Create overlay for board area only
+            overlay = pygame.Surface((board_px_w, board_px_h), pygame.SRCALPHA)
+            overlay.fill((0, 0, 0, 255))
 
-            center = self._get_snake_head_screen_position(world)
+            # Get snake head position directly from world
+            snakes = world.registry.query_by_type_and_components(
+                EntityType.SNAKE, "position", "interpolation"
+            )
+            if not snakes:
+                snakes = world.registry.query_by_type_and_components(
+                    EntityType.SNAKE, "position"
+                )
+            if not snakes:
+                self._renderer.blit(overlay, (offset_x, offset_y))
+                return
+
+            snake = next(iter(snakes.values()))
+            position = getattr(snake, "position", None)
+            interpolation = getattr(snake, "interpolation", None)
+            if not position:
+                self._renderer.blit(overlay, (offset_x, offset_y))
+                return
+
+            # Calculate vision center in overlay coordinates
+            cx = position.x * cell_size + cell_size / 2
+            cy = position.y * cell_size + cell_size / 2
+
+            # Apply smooth interpolation if available
+            if interpolation:
+                prev_cx = position.prev_x * cell_size + cell_size / 2
+                prev_cy = position.prev_y * cell_size + cell_size / 2
+                # Handle wrapping interpolation
+                if interpolation.wrapped_axis in ("x", "both"):
+                    # Wrapping on X - interpolate in the direction of movement
+                    if abs(cx - prev_cx) > board_px_w / 2:
+                        if cx < prev_cx:
+                            cx += board_px_w
+                        else:
+                            prev_cx += board_px_w
+                if interpolation.wrapped_axis in ("y", "both"):
+                    # Wrapping on Y - interpolate in the direction of movement
+                    if abs(cy - prev_cy) > board_px_h / 2:
+                        if cy < prev_cy:
+                            cy += board_px_h
+                        else:
+                            prev_cy += board_px_h
+                # Linear interpolation
+                cx = prev_cx + (cx - prev_cx) * interpolation.alpha
+                cy = prev_cy + (cy - prev_cy) * interpolation.alpha
+                # Wrap back to board bounds
+                cx = cx % board_px_w
+                cy = cy % board_px_h
             radius_px = max(8, int(lights_out_state.radius * cell_size))
 
-            # Convert center to overlay-local coordinates
-            if center is not None and overlay_blit_pos is not None:
-                local_center = (center[0] - overlay_blit_pos[0], center[1] - overlay_blit_pos[1])
-            else:
-                local_center = None
+            # Check if electric walls are enabled
+            electric_walls = (
+                self._settings.get("electric_walls") if self._settings else True
+            )
 
-            if local_center:
-                # carve a hole around the snake head (local coords)
-                pygame.draw.circle(overlay, (0, 0, 0, 0), local_center, radius_px)
+            # Draw vision circles
+            self._draw_vision_circle(
+                overlay, cx, cy, radius_px, board_px_w, board_px_h, electric_walls
+            )
 
-            # Reveal apples only when their glow overlaps the snake's vision.
-            try:
-                from ecs.entities.entity import EntityType
+            # Reveal apples
+            self._draw_apple_glows(
+                world,
+                overlay,
+                cx,
+                cy,
+                radius_px,
+                cell_size,
+                board_px_w,
+                board_px_h,
+                electric_walls,
+            )
 
-                # Apple glow radius: 2 cells
-                apple_radius_px = max(4, int(2 * cell_size))
-                apples = world.registry.query_by_type(EntityType.APPLE)
-                for _, apple in apples.items():
-                    pos = getattr(apple, "position", None)
-                    if not pos:
-                        continue
-                    # apple position relative to board (local coords)
-                    local_ax = int(pos.x * cell_size + cell_size / 2)
-                    local_ay = int(pos.y * cell_size + cell_size / 2)
-                    # Only carve apple hole if apple glow intersects snake vision
-                    if local_center:
-                        dx = local_ax - local_center[0]
-                        dy = local_ay - local_center[1]
-                        if dx * dx + dy * dy <= (radius_px + apple_radius_px) ** 2:
-                            pygame.draw.circle(overlay, (0, 0, 0, 0), (local_ax, local_ay), apple_radius_px)
-            except Exception:
-                pass
-
-            # Blit overlay at board offset so UI above it remains visible
-            self._renderer.blit(overlay, overlay_blit_pos)
+            # Blit overlay at board offset
+            self._renderer.blit(overlay, (offset_x, offset_y))
 
         except Exception:
-            # Avoid breaking rendering if anything goes wrong
+            pass
+
+    def _draw_vision_circle(
+        self, overlay, cx, cy, radius_px, board_w, board_h, electric_walls
+    ):
+        """Draw vision circle(s) at the given center, handling wrapping if needed."""
+        # Always draw at primary position
+        pygame.draw.circle(overlay, (0, 0, 0, 0), (int(cx), int(cy)), radius_px)
+        # If walls wrap, draw at wrapped positions when near edges
+        if not electric_walls:
+            # Draw wrapped circles for seamless edge wrapping
+            if cx - radius_px < 0:  # Near left
+                pygame.draw.circle(
+                    overlay, (0, 0, 0, 0), (int(cx + board_w), int(cy)), radius_px
+                )
+            if cx + radius_px > board_w:  # Near right
+                pygame.draw.circle(
+                    overlay, (0, 0, 0, 0), (int(cx - board_w), int(cy)), radius_px
+                )
+            if cy - radius_px < 0:  # Near top
+                pygame.draw.circle(
+                    overlay, (0, 0, 0, 0), (int(cx), int(cy + board_h)), radius_px
+                )
+            if cy + radius_px > board_h:  # Near bottom
+                pygame.draw.circle(
+                    overlay, (0, 0, 0, 0), (int(cx), int(cy - board_h)), radius_px
+                )
+
+            # Corner cases
+            if cx - radius_px < 0 and cy - radius_px < 0:
+                pygame.draw.circle(
+                    overlay,
+                    (0, 0, 0, 0),
+                    (int(cx + board_w), int(cy + board_h)),
+                    radius_px,
+                )
+            if cx + radius_px > board_w and cy - radius_px < 0:
+                pygame.draw.circle(
+                    overlay,
+                    (0, 0, 0, 0),
+                    (int(cx - board_w), int(cy + board_h)),
+                    radius_px,
+                )
+            if cx - radius_px < 0 and cy + radius_px > board_h:
+                pygame.draw.circle(
+                    overlay,
+                    (0, 0, 0, 0),
+                    (int(cx + board_w), int(cy - board_h)),
+                    radius_px,
+                )
+            if cx + radius_px > board_w and cy + radius_px > board_h:
+                pygame.draw.circle(
+                    overlay,
+                    (0, 0, 0, 0),
+                    (int(cx - board_w), int(cy - board_h)),
+                    radius_px,
+                )
+
+    def _draw_apple_glows(
+        self,
+        world,
+        overlay,
+        cx,
+        cy,
+        radius_px,
+        cell_size,
+        board_w,
+        board_h,
+        electric_walls,
+    ):
+        """Draw apple glows when they're visible in the vision radius."""
+        try:
+            apple_radius_px = max(4, int(1.5 * cell_size))
+            apples = world.registry.query_by_type(EntityType.APPLE)
+            for _, apple in apples.items():
+                pos = getattr(apple, "position", None)
+                if not pos:
+                    continue
+                ax = pos.x * cell_size + cell_size / 2
+                ay = pos.y * cell_size + cell_size / 2
+                # Check if apple is visible from any vision position
+                vision_positions = [(cx, cy)]
+                if not electric_walls:
+                    if cx - radius_px < 0:
+                        vision_positions.append((cx + board_w, cy))
+                    if cx + radius_px > board_w:
+                        vision_positions.append((cx - board_w, cy))
+                    if cy - radius_px < 0:
+                        vision_positions.append((cx, cy + board_h))
+                    if cy + radius_px > board_h:
+                        vision_positions.append((cx, cy - board_h))
+                    if cx - radius_px < 0 and cy - radius_px < 0:
+                        vision_positions.append((cx + board_w, cy + board_h))
+                    if cx + radius_px > board_w and cy - radius_px < 0:
+                        vision_positions.append((cx - board_w, cy + board_h))
+                    if cx - radius_px < 0 and cy + radius_px > board_h:
+                        vision_positions.append((cx + board_w, cy - board_h))
+                    if cx + radius_px > board_w and cy + radius_px > board_h:
+                        vision_positions.append((cx - board_w, cy - board_h))
+
+                for vx, vy in vision_positions:
+                    dx = ax - vx
+                    dy = ay - vy
+                    if dx * dx + dy * dy <= (radius_px + apple_radius_px) ** 2:
+                        pygame.draw.circle(
+                            overlay, (0, 0, 0, 0), (int(ax), int(ay)), apple_radius_px
+                        )
+                        break
+        except Exception:
             pass
 
     def draw_pause_overlay(self, surface_width: int, surface_height: int) -> None:

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -241,7 +241,7 @@ class OverlayRenderSystem(BaseSystem):
                 return
 
             overlay = pygame.Surface((surface_width, surface_height), pygame.SRCALPHA)
-            overlay.fill((0, 0, 0, 240))
+            overlay.fill((0, 0, 0, 252))
 
             center = self._get_snake_head_screen_position(world)
             radius_px = max(

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -217,45 +217,61 @@ class OverlayRenderSystem(BaseSystem):
             if not game_state.lights_out_active:
                 return
 
-            overlay = pygame.Surface((surface_width, surface_height), pygame.SRCALPHA)
-            # Pure black outside illuminated areas (user requested fully black)
-            overlay.fill((0, 0, 0, 255))
+            # Create overlay only for the board area so the top UI/scoreboard
+            # remains visible and is not blacked out.
+            cell_size = getattr(world.board, "cell_size", 16)
+            board_px_w = getattr(world.board, "width", 0) * cell_size
+            board_px_h = getattr(world.board, "height", 0) * cell_size
+            offset_x, offset_y = self._get_board_offset()
+
+            # If board has zero size, fall back to full-surface overlay
+            if board_px_w <= 0 or board_px_h <= 0:
+                overlay = pygame.Surface((surface_width, surface_height), pygame.SRCALPHA)
+                overlay.fill((0, 0, 0, 255))
+                overlay_blit_pos = (0, 0)
+            else:
+                overlay = pygame.Surface((board_px_w, board_px_h), pygame.SRCALPHA)
+                overlay.fill((0, 0, 0, 255))
+                overlay_blit_pos = (offset_x, offset_y)
 
             center = self._get_snake_head_screen_position(world)
-            radius_px = max(
-                8,
-                int(lights_out_state.radius * getattr(world.board, "cell_size", 16)),
-            )
+            radius_px = max(8, int(lights_out_state.radius * cell_size))
 
-            if center:
-                # carve a hole around the snake head
-                pygame.draw.circle(overlay, (0, 0, 0, 0), center, radius_px)
+            # Convert center to overlay-local coordinates
+            if center is not None and overlay_blit_pos is not None:
+                local_center = (center[0] - overlay_blit_pos[0], center[1] - overlay_blit_pos[1])
+            else:
+                local_center = None
+
+            if local_center:
+                # carve a hole around the snake head (local coords)
+                pygame.draw.circle(overlay, (0, 0, 0, 0), local_center, radius_px)
 
             # Reveal apples only when their glow overlaps the snake's vision.
             try:
                 from ecs.entities.entity import EntityType
 
-                cell_size = getattr(world.board, "cell_size", 16)
                 # Apple glow radius: 2 cells
                 apple_radius_px = max(4, int(2 * cell_size))
                 apples = world.registry.query_by_type(EntityType.APPLE)
-                offset_x, offset_y = self._get_board_offset()
                 for _, apple in apples.items():
                     pos = getattr(apple, "position", None)
                     if not pos:
                         continue
-                    ax = int(pos.x * cell_size + offset_x + cell_size / 2)
-                    ay = int(pos.y * cell_size + offset_y + cell_size / 2)
+                    # apple position relative to board (local coords)
+                    local_ax = int(pos.x * cell_size + cell_size / 2)
+                    local_ay = int(pos.y * cell_size + cell_size / 2)
                     # Only carve apple hole if apple glow intersects snake vision
-                    if center:
-                        dx = ax - center[0]
-                        dy = ay - center[1]
+                    if local_center:
+                        dx = local_ax - local_center[0]
+                        dy = local_ay - local_center[1]
                         if dx * dx + dy * dy <= (radius_px + apple_radius_px) ** 2:
-                            pygame.draw.circle(overlay, (0, 0, 0, 0), (ax, ay), apple_radius_px)
+                            pygame.draw.circle(overlay, (0, 0, 0, 0), (local_ax, local_ay), apple_radius_px)
             except Exception:
                 pass
 
-            self._renderer.blit(overlay, (0, 0))
+            # Blit overlay at board offset so UI above it remains visible
+            self._renderer.blit(overlay, overlay_blit_pos)
 
         except Exception:
             # Avoid breaking rendering if anything goes wrong

--- a/src/game/game_mode_settings.py
+++ b/src/game/game_mode_settings.py
@@ -27,6 +27,7 @@ appear when that mode is selected.
 # Available game modes
 GAME_MODES = [
     "Classic",
+    "Lights Out",
     # future modes can be added here:
     # "Box Mode",
     # "Cheese Mode",
@@ -44,6 +45,38 @@ GAME_MODE_SETTINGS = {
         "settings": [
             # no mode-specific settings for classic mode yet
             # future settings can be added here
+        ],
+    },
+    "Lights Out": {
+        "description": "Periodic blackout; only a small circle around the head is visible.",
+        "settings": [
+            {
+                "key": "lights_out_interval",
+                "label": "  Blackout every (s)",
+                "type": "float",
+                "min": 3.0,
+                "max": 30.0,
+                "step": 0.5,
+                "default": 12.0,
+            },
+            {
+                "key": "lights_out_duration",
+                "label": "  Blackout duration (s)",
+                "type": "float",
+                "min": 1.0,
+                "max": 10.0,
+                "step": 0.5,
+                "default": 4.0,
+            },
+            {
+                "key": "lights_out_radius",
+                "label": "  Vision radius (cells)",
+                "type": "int",
+                "min": 2,
+                "max": 10,
+                "step": 1,
+                "default": 4,
+            },
         ],
     },
     # example of how to add mode-specific settings in the future:

--- a/src/game/game_mode_settings.py
+++ b/src/game/game_mode_settings.py
@@ -27,12 +27,12 @@ appear when that mode is selected.
 # Available game modes
 GAME_MODES = [
     "Classic",
-    "Lights Out",
     # future modes can be added here:
     # "Box Mode",
     # "Cheese Mode",
     # "Tail Mode",
     # "Shrinking Snake Mode",
+    # "Lights Out",
 ]
 
 
@@ -45,38 +45,6 @@ GAME_MODE_SETTINGS = {
         "settings": [
             # no mode-specific settings for classic mode yet
             # future settings can be added here
-        ],
-    },
-    "Lights Out": {
-        "description": "Periodic blackout; only a small circle around the head is visible.",
-        "settings": [
-            {
-                "key": "lights_out_interval",
-                "label": "  Blackout every (s)",
-                "type": "float",
-                "min": 3.0,
-                "max": 30.0,
-                "step": 0.5,
-                "default": 12.0,
-            },
-            {
-                "key": "lights_out_duration",
-                "label": "  Blackout duration (s)",
-                "type": "float",
-                "min": 1.0,
-                "max": 10.0,
-                "step": 0.5,
-                "default": 4.0,
-            },
-            {
-                "key": "lights_out_radius",
-                "label": "  Vision radius (cells)",
-                "type": "int",
-                "min": 2,
-                "max": 10,
-                "step": 1,
-                "default": 4,
-            },
         ],
     },
     # example of how to add mode-specific settings in the future:

--- a/src/game/game_modes_registry.py
+++ b/src/game/game_modes_registry.py
@@ -80,8 +80,8 @@ ACTUAL_GAME_MODES = [
     },
     {
         "name": LIGHTS_OUT_MODE_NAME,
-        "description": "Periodic blackouts with a small vision circle around the head.",
-        "detailed_info": "Every interval the arena goes dark for a short duration. Only a small circle around the snake's head stays lit; plan routes from memory. A small on-screen timer shows blackout time remaining.",
+        "description": "Map completely black. Limited vision around the snake head.",
+        "detailed_info": "The arena is completely dark. Each snake has a constant 4-tile vision radius around its head. Apples emit a 2-tile glow and are visible only when that glow intersects your vision. No timers or periodic blackouts.",
     },
 ]
 

--- a/src/game/game_modes_registry.py
+++ b/src/game/game_modes_registry.py
@@ -30,6 +30,7 @@ SHRINKING_MODE_NAME = "Shrinking Mode"
 GAME_MODE_TELEPORT = "Teleport"
 BOX_MODE_NAME = "Box Mode"
 TRAIL_MODE_NAME = "Trail Mode"
+LIGHTS_OUT_MODE_NAME = "Lights Out"
 
 ACTUAL_GAME_MODES = [
     {
@@ -77,6 +78,11 @@ ACTUAL_GAME_MODES = [
         "description": "Every tile the snake moves through becomes a permanent obstacle.",
         "detailed_info": "Leave your mark - permanently! Every tile you move through becomes a solid obstacle that remains for the rest of the game. The board fills up as you play, creating an ever-shrinking maze. Requires careful path planning to avoid trapping yourself. How long can you survive?",
     },
+    {
+        "name": LIGHTS_OUT_MODE_NAME,
+        "description": "Periodic blackouts with a small vision circle around the head.",
+        "detailed_info": "Every interval the arena goes dark for a short duration. Only a small circle around the snake's head stays lit; plan routes from memory. A small on-screen timer shows blackout time remaining.",
+    },
 ]
 
 RANDOM_MODE_LABEL = "Random"
@@ -90,6 +96,7 @@ __all__ = [
     "GAME_MODE_TELEPORT",
     "BOX_MODE_NAME",
     "TRAIL_MODE_NAME",
+    "LIGHTS_OUT_MODE_NAME",
     "ACTUAL_GAME_MODES",
     "RANDOM_MODE_LABEL",
     "RANDOM_MODE_INDEX",

--- a/src/game/game_modes_registry.py
+++ b/src/game/game_modes_registry.py
@@ -81,7 +81,7 @@ ACTUAL_GAME_MODES = [
     {
         "name": LIGHTS_OUT_MODE_NAME,
         "description": "Map completely black. Limited vision around the snake head.",
-        "detailed_info": "The arena is completely dark. Each snake has a constant 4-tile vision radius around its head. Apples emit a 2-tile glow and are visible only when that glow intersects your vision. No timers or periodic blackouts.",
+        "detailed_info": "The arena is completely dark. Each snake has a constant 4-tile vision radius around its head. Apples emit a 2-tile glow and are visible only when that glow intersects your vision. Choose your next move carefully!",
     },
 ]
 

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -207,7 +207,9 @@ class GameplayScene(BaseScene):
                     if self._settings and bool(self._settings.get("enable_hunger"))
                     else []
                 ),
-                LightsOutSystem(self._settings),  # 8: enforce always-on Lights Out vision radius
+                LightsOutSystem(
+                    self._settings
+                ),  # 8: enforce always-on Lights Out vision radius
                 scoring_system,  # 9: track score and high score
                 ObstacleGenerationSystem(
                     100, 8, 2, None

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -47,6 +47,7 @@ from ecs.systems.obstacle_generation import ObstacleGenerationSystem
 from ecs.systems.settings_apply import SettingsApplySystem
 from ecs.systems.trail_generation import TrailGenerationSystem
 from ecs.systems.trail_decay import TrailDecaySystem
+from ecs.systems.lights_out import LightsOutSystem
 from game.scenes.game_modes import get_resolved_game_mode
 from game.game_modes_registry import CLASSIC_MODE_NAME, BOX_MODE_NAME
 from ecs.systems.hunger import HungerSystem
@@ -206,29 +207,30 @@ class GameplayScene(BaseScene):
                     if self._settings and bool(self._settings.get("enable_hunger"))
                     else []
                 ),
-                scoring_system,  # 8: track score and high score
+                LightsOutSystem(self._settings),  # 8: manage blackout timer toggles
+                scoring_system,  # 9: track score and high score
                 ObstacleGenerationSystem(
                     100, 8, 2, None
-                ),  # 9: generate obstacles with connectivity guarantees
-                settings_apply_system,  # 10: apply runtime settings changes
+                ),  # 10: generate obstacles with connectivity guarantees
+                settings_apply_system,  # 11: apply runtime settings changes
             ]
         )
 
         self._systems.extend(game_logic_systems)
 
-        # rendering and audio systems (indices 10+, always run even when paused)
+        # rendering and audio systems (indices 12+, always run even when paused)
         self._systems.extend(
             [
                 InterpolationSystem(
                     self._get_electric_walls(), self._get_electric_walls
-                ),  # 10: calculate smooth positions for rendering
+                ),  # 12: calculate smooth positions for rendering
                 AudioSystem(
                     self._sfx_queue_service, None, None, 0.2
-                ),  # 11: play sounds and music
+                ),  # 13: play sounds and music
             ]
         )
 
-        # render systems (11-14: draw board, entities, snake, UI)
+        # render systems (14-18: draw board, entities, snake, UI, overlays)
         if self._renderer:
             self._board_render_system = BoardRenderSystem(self._renderer)
             self._entity_render_system = EntityRenderSystem(self._renderer)
@@ -243,6 +245,7 @@ class GameplayScene(BaseScene):
                     self._entity_render_system,
                     self._snake_render_system,
                     self._ui_render_system,
+                    self._overlay_render_system,
                 ]
             )
 
@@ -272,9 +275,9 @@ class GameplayScene(BaseScene):
         game_state = self._get_game_state()
         is_paused = game_state.paused if game_state else False
 
-        # pause game logic systems (1-9) but keep input (0) and rendering (10+) running
+        # pause game logic systems (1-11) but keep input (0) and rendering (12+) running
         GAME_LOGIC_START = 1
-        GAME_LOGIC_END = 9
+        GAME_LOGIC_END = 11
 
         for i, system in enumerate(self._systems):
             # skip game logic when paused (movement, collision, spawning, etc.)

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -239,13 +239,15 @@ class GameplayScene(BaseScene):
             )
             self._ui_render_system = UIRenderSystem(self._renderer, self._settings)
             # overlay_render_system already created earlier (before InputSystem)
+            # Draw order: board, entities, snake, overlay, UI
+            # Overlay must be blitted before UI so HUD elements remain visible above it.
             self._systems.extend(
                 [
                     self._board_render_system,
                     self._entity_render_system,
                     self._snake_render_system,
-                    self._ui_render_system,
                     self._overlay_render_system,
+                    self._ui_render_system,
                 ]
             )
 

--- a/src/game/scenes/gameplay.py
+++ b/src/game/scenes/gameplay.py
@@ -207,7 +207,7 @@ class GameplayScene(BaseScene):
                     if self._settings and bool(self._settings.get("enable_hunger"))
                     else []
                 ),
-                LightsOutSystem(self._settings),  # 8: manage blackout timer toggles
+                LightsOutSystem(self._settings),  # 8: enforce always-on Lights Out vision radius
                 scoring_system,  # 9: track score and high score
                 ObstacleGenerationSystem(
                     100, 8, 2, None

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -212,24 +212,9 @@ class GameInitializer:
         # Create Lights Out state entity if mode is active
         if current_mode == LIGHTS_OUT_MODE_NAME:
 
-            def _get_setting(key: str, default):
-                if self._settings and hasattr(self._settings, "get"):
-                    value = self._settings.get(key)
-                    return default if value is None else value
-                return default
-
-            lights_out_interval = float(_get_setting("lights_out_interval", 12.0))
-            lights_out_duration = float(_get_setting("lights_out_duration", 4.0))
-            lights_out_radius = int(_get_setting("lights_out_radius", 4))
-
             class LightsOutEntity:
                 def __init__(self):
-                    self.lights_out_state = LightsOutState(
-                        interval=lights_out_interval,
-                        duration=lights_out_duration,
-                        radius=lights_out_radius,
-                        timer=lights_out_interval,  # Start with cooldown
-                    )
+                    self.lights_out_state = LightsOutState(radius=4)
 
                 def get_type(self):
                     return None

--- a/src/game/services/game_initializer.py
+++ b/src/game/services/game_initializer.py
@@ -36,6 +36,7 @@ from game.game_modes_registry import (
     AUTOPLAY_MODE_NAME,
     BOX_MODE_NAME,
     TRAIL_MODE_NAME,
+    LIGHTS_OUT_MODE_NAME,
 )
 
 
@@ -172,6 +173,7 @@ class GameInitializer:
             world: ECS world instance
         """
         from ecs.components.game_state import GameState
+        from ecs.components.lights_out_state import LightsOutState
 
         current_mode = self._game_mode
         moving_apples_enabled = current_mode == MOVING_APPLE_MODE_NAME
@@ -183,6 +185,7 @@ class GameInitializer:
         cheese_mode_enabled = current_mode == CHEESE_MODE_NAME
         trail_mode_enabled = current_mode == TRAIL_MODE_NAME
         shrinking_mode_enabled = current_mode == SHRINKING_MODE_NAME
+        lights_out_enabled = current_mode == LIGHTS_OUT_MODE_NAME
 
         class GameStateEntity:
             def __init__(self):
@@ -197,6 +200,7 @@ class GameInitializer:
                     cheese_mode_enabled=cheese_mode_enabled,
                     trail_mode_enabled=trail_mode_enabled,
                     shrinking_mode_enabled=shrinking_mode_enabled,
+                    lights_out_enabled=lights_out_enabled,
                 )
 
             def get_type(self):
@@ -204,6 +208,34 @@ class GameInitializer:
 
         game_state_entity = GameStateEntity()
         world.registry.add(game_state_entity)
+
+        # Create Lights Out state entity if mode is active
+        if current_mode == LIGHTS_OUT_MODE_NAME:
+
+            def _get_setting(key: str, default):
+                if self._settings and hasattr(self._settings, "get"):
+                    value = self._settings.get(key)
+                    return default if value is None else value
+                return default
+
+            lights_out_interval = float(_get_setting("lights_out_interval", 12.0))
+            lights_out_duration = float(_get_setting("lights_out_duration", 4.0))
+            lights_out_radius = int(_get_setting("lights_out_radius", 4))
+
+            class LightsOutEntity:
+                def __init__(self):
+                    self.lights_out_state = LightsOutState(
+                        interval=lights_out_interval,
+                        duration=lights_out_duration,
+                        radius=lights_out_radius,
+                        timer=lights_out_interval,  # Start with cooldown
+                    )
+
+                def get_type(self):
+                    return None
+
+            lights_out_entity = LightsOutEntity()
+            world.registry.add(lights_out_entity)
 
         # NOTE: For autoplay mode, game_started is NOT set here.
         # AutoplaySystem sets it after computing the first safe direction.

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -46,6 +46,9 @@ class GameSettings:
         "speed_increase_rate": "10%",  # Speed increase per apple: 5% or 10%
         "enable_hunger": False,
         "game_mode": "Classic",  # current game mode
+        "lights_out_interval": 12.0,
+        "lights_out_duration": 4.0,
+        "lights_out_radius": 4,
     }
 
     # Settings that are restricted/forced for Autoplay mode
@@ -152,6 +155,36 @@ class GameSettings:
             "key": "electric_walls",
             "label": "Electric walls",
             "type": "bool",
+            "requires_reset": True,
+            "category": "Gameplay",
+        },
+        {
+            "key": "lights_out_interval",
+            "label": "Lights-out interval (s)",
+            "type": "float",
+            "min": 3.0,
+            "max": 30.0,
+            "step": 0.5,
+            "requires_reset": True,
+            "category": "Gameplay",
+        },
+        {
+            "key": "lights_out_duration",
+            "label": "Lights-out duration (s)",
+            "type": "float",
+            "min": 1.0,
+            "max": 10.0,
+            "step": 0.5,
+            "requires_reset": True,
+            "category": "Gameplay",
+        },
+        {
+            "key": "lights_out_radius",
+            "label": "Lights-out radius (cells)",
+            "type": "int",
+            "min": 2,
+            "max": 10,
+            "step": 1,
             "requires_reset": True,
             "category": "Gameplay",
         },

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -46,9 +46,6 @@ class GameSettings:
         "speed_increase_rate": "10%",  # Speed increase per apple: 5% or 10%
         "enable_hunger": False,
         "game_mode": "Classic",  # current game mode
-        "lights_out_interval": 12.0,
-        "lights_out_duration": 4.0,
-        "lights_out_radius": 4,
     }
 
     # Settings that are restricted/forced for Autoplay mode
@@ -155,36 +152,6 @@ class GameSettings:
             "key": "electric_walls",
             "label": "Electric walls",
             "type": "bool",
-            "requires_reset": True,
-            "category": "Gameplay",
-        },
-        {
-            "key": "lights_out_interval",
-            "label": "Lights-out interval (s)",
-            "type": "float",
-            "min": 3.0,
-            "max": 30.0,
-            "step": 0.5,
-            "requires_reset": True,
-            "category": "Gameplay",
-        },
-        {
-            "key": "lights_out_duration",
-            "label": "Lights-out duration (s)",
-            "type": "float",
-            "min": 1.0,
-            "max": 10.0,
-            "step": 0.5,
-            "requires_reset": True,
-            "category": "Gameplay",
-        },
-        {
-            "key": "lights_out_radius",
-            "label": "Lights-out radius (cells)",
-            "type": "int",
-            "min": 2,
-            "max": 10,
-            "step": 1,
             "requires_reset": True,
             "category": "Gameplay",
         },


### PR DESCRIPTION
### Description 
**Concept:**
This pull request introduces the new "Lights Out" game mode, which restricts player vision to a small radius around the snake's head and adds supporting systems and rendering logic. The implementation includes a new state component, system, and overlay rendering for the blackout effect, as well as updates to the game mode registry and scene setup to integrate the new mode.

**Problems faced:**
- Adequation to Electric Walls Off 
- Deciding the radius 

### Gameplay
![lights_out](https://github.com/user-attachments/assets/0779919c-2e9b-4b8f-ab7a-e142ba5b5500)


Closes #487 