### PR TITLE
[MINOR] changed some settings to decrease snake clunkiness

### DIFF
--- a/src/ecs/components/input_buffer.py
+++ b/src/ecs/components/input_buffer.py
@@ -7,4 +7,4 @@ class InputBuffer:
     """Buffered directions for an entity (snake). Each entry is (dx, dy)."""
 
     moves: List[Tuple[int, int]] = field(default_factory=list)
-    max_len: int = 2  # maximum number of buffered moves
+    max_len: int = 1  # maximum number of buffered moves

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -32,9 +32,9 @@ class GameSettings:
 
     # Default settings values
     DEFAULT_SETTINGS = {
-        "cells_per_side": 16,  # Will be calculated from screen size
-        "initial_speed": 4.0,
-        "max_speed": 20.0,
+        "cells_per_side": 24,  # Will be calculated from screen size
+        "initial_speed": 15.0,
+        "max_speed": 30.0,
         "obstacle_difficulty": "None",
         "number_of_apples": 1,
         "background_music": True,


### PR DESCRIPTION
Some minor changes were done to decrease the clunkiness of controlling the snake (issue #502 ). 

- The base speed was increased to decrease the delay between the user input and its corresponding snake movement.
- The board size was increased to compensate the base speed being increased.
- The maximum amount of buffered directions was decreased to 1.