### PR TITLE
[BUG] Snake turns to wrong direction -- Fixed

### DIFF
--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -115,12 +115,8 @@ def create_snake(
         initial_segments = []
         initial_size = 1
 
-    # In autoplay mode, start with zero velocity so autoplay can set the first direction
-    # Otherwise start moving right
-    if autoplay_mode:
-        initial_dx, initial_dy = 0, 0
-    else:
-        initial_dx, initial_dy = 1, 0
+    # Start with zero velocity so the user can set the first direction
+    initial_dx, initial_dy = 0, 0
 
     # create snake entity with all required components
     snake = Snake(

--- a/src/ecs/prefabs/snake.py
+++ b/src/ecs/prefabs/snake.py
@@ -115,8 +115,12 @@ def create_snake(
         initial_segments = []
         initial_size = 1
 
-    # Start with zero velocity so the user can set the first direction
-    initial_dx, initial_dy = 0, 0
+    # In autoplay mode, start with zero velocity so autoplay can set the first direction
+    # Otherwise start moving right
+    if autoplay_mode:
+        initial_dx, initial_dy = 0, 0
+    else:
+        initial_dx, initial_dy = 1, 0
 
     # create snake entity with all required components
     snake = Snake(

--- a/src/ecs/systems/snake_render.py
+++ b/src/ecs/systems/snake_render.py
@@ -202,9 +202,9 @@ class SnakeRenderSystem(BaseSystem):
             dy = -1
         elif dy < -1:
             dy = 1
-        # Default to DOWN if no movement
+        # Default to RIGHT if no movement
         if dx == 0 and dy == 0:
-            return (0, 1)
+            return (1, 0)
         return (dx, dy)
 
     def _draw_snake_head(


### PR DESCRIPTION
So, there was an error (issue #500 ) that if you started the game, and specifically pressed the left-arrow or A-button, the snake would turn to the right instead of left.

It was because of this piece of code, localized on prefabs/snake.py:
```
    # In autoplay mode, start with zero velocity so autoplay can set the first direction
    # Otherwise start moving right
    if autoplay_mode:
        initial_dx, initial_dy = 0, 0
    else:
        initial_dx, initial_dy = 1, 0
```
It initialized the initial_dx with 1, that meant to move right.

The fix sets the initial direction to (0, 0) when the game starts in manual mode, so the first user input defines the direction.