### PR TITLE
[MINOR] Fixed min size and increased max size

### DIFF
--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -551,7 +551,7 @@ class OverlayRenderSystem(BaseSystem):
                     current_grid_size = 20
                     if self._config:
                         desired_cells = max(
-                            10, int(self._settings.get("cells_per_side"))
+                            5, int(self._settings.get("cells_per_side"))
                         )
                         current_grid_size = self._config.get_optimal_grid_size(
                             desired_cells

--- a/src/ecs/systems/overlay_render.py
+++ b/src/ecs/systems/overlay_render.py
@@ -550,9 +550,7 @@ class OverlayRenderSystem(BaseSystem):
                     # Calculate current grid size for display
                     current_grid_size = 20
                     if self._config:
-                        desired_cells = max(
-                            5, int(self._settings.get("cells_per_side"))
-                        )
+                        desired_cells = int(self._settings.get("cells_per_side"))
                         current_grid_size = self._config.get_optimal_grid_size(
                             desired_cells
                         )

--- a/src/ecs/systems/settings_apply.py
+++ b/src/ecs/systems/settings_apply.py
@@ -156,7 +156,7 @@ class SettingsApplySystem(BaseSystem):
             desired_cells: Desired number of cells per side
         """
         # ensure minimum size
-        desired_cells = max(10, int(desired_cells))
+        desired_cells = max(5, int(desired_cells))
 
         # For autoplay mode, enforce even grid size (maze algorithm requires it)
         from game.game_modes_registry import AUTOPLAY_MODE_NAME

--- a/src/ecs/systems/settings_apply.py
+++ b/src/ecs/systems/settings_apply.py
@@ -155,8 +155,6 @@ class SettingsApplySystem(BaseSystem):
             world: ECS world instance
             desired_cells: Desired number of cells per side
         """
-        # ensure minimum size
-        desired_cells = max(5, int(desired_cells))
 
         # For autoplay mode, enforce even grid size (maze algorithm requires it)
         from game.game_modes_registry import AUTOPLAY_MODE_NAME

--- a/src/ecs/systems/ui/settings_applicator.py
+++ b/src/ecs/systems/ui/settings_applicator.py
@@ -133,7 +133,7 @@ class SettingsApplicator:
         old_grid = self._state.grid_size
 
         # Calculate new grid size from desired cells per side
-        desired_cells = max(10, int(settings.get("cells_per_side")))
+        desired_cells = max(5, int(settings.get("cells_per_side")))
         new_grid_size = self._config.get_optimal_grid_size(desired_cells)
 
         # Calculate obstacles from difficulty

--- a/src/ecs/systems/ui/settings_applicator.py
+++ b/src/ecs/systems/ui/settings_applicator.py
@@ -133,7 +133,7 @@ class SettingsApplicator:
         old_grid = self._state.grid_size
 
         # Calculate new grid size from desired cells per side
-        desired_cells = max(5, int(settings.get("cells_per_side")))
+        desired_cells = int(settings.get("cells_per_side"))
         new_grid_size = self._config.get_optimal_grid_size(desired_cells)
 
         # Calculate obstacles from difficulty

--- a/src/game/settings.py
+++ b/src/game/settings.py
@@ -162,7 +162,7 @@ class GameSettings:
             "label": "Board size",
             "type": "int",
             "min": 5,
-            "max": 60,
+            "max": 90,
             "step": 1,
             "requires_reset": True,
             "category": "Display",


### PR DESCRIPTION
This fixes a bug that happened with #505, because some values on other files were not changed. Furthermore, it increases the maximum board size from 60 to 90, related to #504, which increased the default board size by 50%.
